### PR TITLE
chore: remove `scope: root` label

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,7 +10,6 @@ updates:
     commit-message:
       prefix: "dependency"
     labels:
-      - "scope: root"
       - "topic: dependency"
       - "package manager: github actions"
       - "priority: medium"
@@ -28,7 +27,6 @@ updates:
     commit-message:
       prefix: "dependency"
     labels:
-      - "scope: root"
       - "topic: dependency"
       - "package manager: pnpm"
       - "priority: medium"
@@ -46,7 +44,6 @@ updates:
     commit-message:
       prefix: "dependency"
     labels:
-      - "scope: root"
       - "topic: dependency"
       - "package manager: nuget"
       - "priority: medium"


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Topic <!-- Required -->

- [ ] Feature <!-- Indicates a relationship with a feature or enhancement -->
- [ ] Test <!-- Indicates a relationship with a testing process -->
- [ ] Build <!-- Indicates a relationship with a build process -->
- [ ] Dependency <!-- Indicates a relationship with a development or production dependency -->
- [ ] Bug <!-- Indicates a relationship with a bug or unintended behavior -->
- [ ] Refactor <!-- Indicates a relationship with a refactoring process -->
- [ ] Style <!-- Indicates a relationship with a code style process -->
- [x] Chore <!-- Indicates a relationship with a maintenance process (does not affect production code) -->
- [ ] Documentation <!-- Indicates a relationship with a documentation process -->
- [ ] Workflow <!-- Indicates a relationship with a CI/CD process -->

## Description <!-- Required -->

Removed `scope: root` [label](https://github.com/daht-x/sagitta-core/labels).

<!-- ## Evidence <!-- Optional -->
