### PR TITLE
chore: remove explicit conversion of `C#` relative paths

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,17 +1,7 @@
-import path from "path";
-
 const rootConfiguration = {
 	"**.md": ["markdownlint --fix", "markdown-link-check --progress --config '.markdownlc.json'"],
 	"**.js": "eslint --fix",
-	"**/*.cs": absolutePaths =>
-	{
-		const currentWorkingDirectory = process.cwd();
-		const relativePaths = absolutePaths
-			.map(absolutePath => path.relative(currentWorkingDirectory, absolutePath))
-			.join(" ");
-		const command = `dotnet format --include ${relativePaths}`;
-		return command;
-	}
+	"**/*.cs": "dotnet format --include"
 };
 
 export default rootConfiguration;


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Topic <!-- Required -->

- [ ] Feature <!-- Indicates a relationship with a feature or enhancement -->
- [ ] Test <!-- Indicates a relationship with a testing process -->
- [ ] Build <!-- Indicates a relationship with a build process -->
- [ ] Dependency <!-- Indicates a relationship with a development or production dependency -->
- [ ] Bug <!-- Indicates a relationship with a bug or unintended behavior -->
- [ ] Refactor <!-- Indicates a relationship with a refactoring process -->
- [ ] Style <!-- Indicates a relationship with a code style process -->
- [x] Chore <!-- Indicates a relationship with a maintenance process (does not affect production code) -->
- [ ] Documentation <!-- Indicates a relationship with a documentation process -->
- [ ] Workflow <!-- Indicates a relationship with a CI/CD process -->

## Description <!-- Required -->

Removed explicit conversion of `C#` relative paths.

<!-- ## Evidence <!-- Optional -->
