### PR TITLE
build: remove `IsContinuousIntegrationEnvironment` property

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,10 +3,9 @@
 		<IsDotProps Condition="'$(MSBuildProjectExtension)' == '.props'">true</IsDotProps>
 		<IsDotCsproj Condition="'$(MSBuildProjectExtension)' == '.csproj'">true</IsDotCsproj>
 		<IsDotPropsOrDotCsproj Condition="$(IsDotProps) == true Or $(IsDotCsproj) == true">true</IsDotPropsOrDotCsproj>
-		<IsContinuousIntegrationEnvironment Condition="'$(GITHUB_ACTIONS)' == 'true'">true</IsContinuousIntegrationEnvironment>
 	</PropertyGroup>
 	<PropertyGroup Condition="$(IsDotCsproj) == true">
-		<ContinuousIntegrationBuild Condition="'$(IsContinuousIntegrationEnvironment)' == true">true</ContinuousIntegrationBuild>
+		<ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
 		<TargetFramework>net7.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Topic <!-- Required -->

- [ ] Feature <!-- Indicates a relationship with a feature or enhancement -->
- [ ] Test <!-- Indicates a relationship with a testing process -->
- [x] Build <!-- Indicates a relationship with a build process -->
- [ ] Dependency <!-- Indicates a relationship with a development or production dependency -->
- [ ] Bug <!-- Indicates a relationship with a bug or unintended behavior -->
- [ ] Refactor <!-- Indicates a relationship with a refactoring process -->
- [ ] Style <!-- Indicates a relationship with a code style process -->
- [ ] Chore <!-- Indicates a relationship with a maintenance process (does not affect production code) -->
- [ ] Documentation <!-- Indicates a relationship with a documentation process -->
- [ ] Workflow <!-- Indicates a relationship with a CI/CD process -->

## Description <!-- Required -->

Removed `IsContinuousIntegrationEnvironment` property.

<!-- ## Evidence <!-- Optional -->
