### PR TITLE
build: remove `IsDotPropsOrDotCsproj` property

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,6 @@
 	<PropertyGroup>
 		<IsDotProps Condition="'$(MSBuildProjectExtension)' == '.props'">true</IsDotProps>
 		<IsDotCsproj Condition="'$(MSBuildProjectExtension)' == '.csproj'">true</IsDotCsproj>
-		<IsDotPropsOrDotCsproj Condition="$(IsDotProps) == true Or $(IsDotCsproj) == true">true</IsDotPropsOrDotCsproj>
 	</PropertyGroup>
 	<PropertyGroup Condition="$(IsDotCsproj) == true">
 		<ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,9 +1,9 @@
 <Project>
-	<PropertyGroup Condition="$(IsDotPropsOrDotCsproj) == true">
+	<PropertyGroup>
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 		<DefaultAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</DefaultAssets>
 	</PropertyGroup>
-	<ItemGroup Condition="$(IsDotPropsOrDotCsproj) == true">
+	<ItemGroup Condition="$(IsDotProps) == true Or $(IsDotCsproj) == true">
 		<PackageVersion Include="SonarAnalyzer.CSharp" Version="9.12.0.78982">
 			<IncludeAssets>$(DefaultAssets)</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Topic <!-- Required -->

- [ ] Feature <!-- Indicates a relationship with a feature or enhancement -->
- [ ] Test <!-- Indicates a relationship with a testing process -->
- [x] Build <!-- Indicates a relationship with a build process -->
- [ ] Dependency <!-- Indicates a relationship with a development or production dependency -->
- [ ] Bug <!-- Indicates a relationship with a bug or unintended behavior -->
- [ ] Refactor <!-- Indicates a relationship with a refactoring process -->
- [ ] Style <!-- Indicates a relationship with a code style process -->
- [ ] Chore <!-- Indicates a relationship with a maintenance process (does not affect production code) -->
- [ ] Documentation <!-- Indicates a relationship with a documentation process -->
- [ ] Workflow <!-- Indicates a relationship with a CI/CD process -->

## Description <!-- Required -->

Removed `IsDotPropsOrDotCsproj` property.

<!-- ## Evidence <!-- Optional -->
