### PR TITLE
dependency: replace `coverlet.collector` with `coverlet.msbuild`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,22 +5,22 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="SonarAnalyzer.CSharp" Version="9.12.0.78982">
-			<IncludeAssets>$(DefaultAssets)</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>$(DefaultAssets)</IncludeAssets>
 		</PackageVersion>
 		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
-			<IncludeAssets>$(DefaultAssets)</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>$(DefaultAssets)</IncludeAssets>
 		</PackageVersion>
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 		<PackageVersion Include="xunit" Version="2.6.1" />
 		<PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3">
-			<IncludeAssets>$(DefaultAssets)</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>$(DefaultAssets)</IncludeAssets>
 		</PackageVersion>
-		<PackageVersion Include="coverlet.collector" Version="6.0.0">
-			<IncludeAssets>$(DefaultAssets)</IncludeAssets>
+		<PackageVersion Include="coverlet.msbuild" Version="6.0.0">
 			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>$(DefaultAssets)</IncludeAssets>
 		</PackageVersion>
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Topic <!-- Required -->

- [ ] Feature <!-- Indicates a relationship with a feature or enhancement -->
- [ ] Test <!-- Indicates a relationship with a testing process -->
- [ ] Build <!-- Indicates a relationship with a build process -->
- [x] Dependency <!-- Indicates a relationship with a development or production dependency -->
- [ ] Bug <!-- Indicates a relationship with a bug or unintended behavior -->
- [ ] Refactor <!-- Indicates a relationship with a refactoring process -->
- [ ] Style <!-- Indicates a relationship with a code style process -->
- [ ] Chore <!-- Indicates a relationship with a maintenance process (does not affect production code) -->
- [ ] Documentation <!-- Indicates a relationship with a documentation process -->
- [ ] Workflow <!-- Indicates a relationship with a CI/CD process -->

## Description <!-- Required -->

Replaced [coverlet.collector](https://www.nuget.org/packages/coverlet.collector) with [coverlet.msbuild](https://www.nuget.org/packages/coverlet.msbuild).

<!-- ## Evidence <!-- Optional -->
