### PR TITLE
build: add naming convention for all assemblies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,9 @@
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<AnalysisMode>all</AnalysisMode>
 		<CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+		<Company>Daht</Company>
+		<AssemblyName>$(Company).$(MSBuildProjectName)</AssemblyName>
+		<RootNamespace>$(AssemblyName)</RootNamespace>
 		<UseArtifactsOutput>true</UseArtifactsOutput>
 	</PropertyGroup>
 	<ItemGroup>


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Topic <!-- Required -->

- [ ] Feature <!-- Indicates a relationship with a feature or enhancement -->
- [ ] Test <!-- Indicates a relationship with a testing process -->
- [x] Build <!-- Indicates a relationship with a build process -->
- [ ] Dependency <!-- Indicates a relationship with a development or production dependency -->
- [ ] Bug <!-- Indicates a relationship with a bug or unintended behavior -->
- [ ] Refactor <!-- Indicates a relationship with a refactoring process -->
- [ ] Style <!-- Indicates a relationship with a code style process -->
- [ ] Chore <!-- Indicates a relationship with a maintenance process (does not affect production code) -->
- [ ] Documentation <!-- Indicates a relationship with a documentation process -->
- [ ] Workflow <!-- Indicates a relationship with a CI/CD process -->

## Description <!-- Required -->

Added naming convention for all assemblies.

<!-- ## Evidence <!-- Optional -->
