### PR TITLE
style: add whitespace after the `Shebang` declaration

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
+
 . "$(dirname -- "$0")/_/husky.sh"
 pnpm exec commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
+
 . "$(dirname -- "$0")/_/husky.sh"
 pnpm exec lint-staged --relative


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Topic <!-- Required -->

- [ ] Feature <!-- Indicates a relationship with a feature or enhancement -->
- [ ] Test <!-- Indicates a relationship with a testing process -->
- [ ] Build <!-- Indicates a relationship with a build process -->
- [ ] Dependency <!-- Indicates a relationship with a development or production dependency -->
- [ ] Bug <!-- Indicates a relationship with a bug or unintended behavior -->
- [ ] Refactor <!-- Indicates a relationship with a refactoring process -->
- [x] Style <!-- Indicates a relationship with a code style process -->
- [ ] Chore <!-- Indicates a relationship with a maintenance process (does not affect production code) -->
- [ ] Documentation <!-- Indicates a relationship with a documentation process -->
- [ ] Workflow <!-- Indicates a relationship with a CI/CD process -->

## Description <!-- Required -->

Added whitespace after the [Shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) declaration.

<!-- ## Evidence <!-- Optional -->
