### PR TITLE
workflow: enable `cancel-in-progress` for redundant runs

### DIFF
--- a/.github/workflows/library.yaml
+++ b/.github/workflows/library.yaml
@@ -24,6 +24,7 @@ on:
       - "*.sln"
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
 env:
   RELEASE_NAME: "${{ github.ref_name }}"
   NUGET_OUTPUT_DIRECTORY: "artifacts/package/release"


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Topic <!-- Required -->

- [ ] Feature <!-- Indicates a relationship with a feature or enhancement -->
- [ ] Test <!-- Indicates a relationship with a testing process -->
- [ ] Build <!-- Indicates a relationship with a build process -->
- [ ] Dependency <!-- Indicates a relationship with a development or production dependency -->
- [ ] Bug <!-- Indicates a relationship with a bug or unintended behavior -->
- [ ] Refactor <!-- Indicates a relationship with a refactoring process -->
- [ ] Style <!-- Indicates a relationship with a code style process -->
- [ ] Chore <!-- Indicates a relationship with a maintenance process (does not affect production code) -->
- [ ] Documentation <!-- Indicates a relationship with a documentation process -->
- [x] Workflow <!-- Indicates a relationship with a CI/CD process -->

## Description <!-- Required -->

Enabled [cancel-in-progress](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) for redundant runs.

<!-- ## Evidence <!-- Optional -->
