### PR TITLE
feature: add second overload of the `Succeed` method

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -6,6 +6,24 @@ public static class Result
 	/// <summary>Creates a new successful result.</summary>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
+	/// <param name="createSuccess">
+	///     <para>Creates the expected success.</para>
+	///     <para>If <paramref name="createSuccess"/> is <see langword="null"/> or its value is <see langword="null"/>, <seealso cref="ArgumentNullException"/> will be thrown.</para>
+	/// </param>
+	/// <returns>A new successful result.</returns>
+	/// <exception cref="ArgumentNullException"/>
+	public static Result<TFailure, TSuccess> Succeed<TFailure, TSuccess>(Func<TSuccess> createSuccess)
+		where TFailure : notnull
+		where TSuccess : notnull
+	{
+		ArgumentNullException.ThrowIfNull(createSuccess);
+		TSuccess success = createSuccess() ?? throw new ArgumentNullException(nameof(createSuccess));
+		return Succeed<TFailure, TSuccess>(success);
+	}
+
+	/// <summary>Creates a new successful result.</summary>
+	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <param name="success">
 	///		<para>The expected success.</para>
 	///     <para>If <paramref name="success"/> is <see langword="null"/>, <seealso cref="ArgumentNullException"/> will be thrown.</para>

--- a/source/Sagitta.Core.csproj
+++ b/source/Sagitta.Core.csproj
@@ -22,15 +22,15 @@
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>
 	<ItemGroup>
-		<None Include="..\icon.png">
+		<None Include="../icon.png">
 			<Visible>false</Visible>
 			<Pack>true</Pack>
-			<PackagePath>\</PackagePath>
+			<PackagePath>/</PackagePath>
 		</None>
-		<None Include="..\readme.md">
+		<None Include="../readme.md">
 			<Visible>false</Visible>
 			<Pack>true</Pack>
-			<PackagePath>\</PackagePath>
+			<PackagePath>/</PackagePath>
 		</None>
 	</ItemGroup>
 	<ItemGroup>

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -8,6 +8,8 @@ public sealed class ResultTest
 
 	#region Succeed
 
+	#region Overload No. 01
+
 	[Fact]
 	[Trait(root, succeed)]
 	public void Succeed_NullSuccess_ArgumentNullException()
@@ -35,6 +37,55 @@ public sealed class ResultTest
 		//Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
 	}
+
+	#endregion
+
+	#region Overload No. 02
+
+	[Fact]
+	[Trait(root, succeed)]
+	public void Succeed_NullCreateSuccess_ArgumentNullException()
+	{
+		//Arrange
+		const Func<string> createSuccess = null!;
+
+		//Act
+		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(static () => _ = Result.Succeed<string, string>(createSuccess));
+
+		//Assert
+		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(createSuccess), actualException);
+	}
+
+	[Fact]
+	[Trait(root, succeed)]
+	public void Succeed_CreateSuccessWithNullValue_ArgumentNullException()
+	{
+		//Arrange
+		Func<string> createSuccess = static () => null!;
+
+		//Act
+		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(() => _ = Result.Succeed<string, string>(createSuccess));
+
+		//Assert
+		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(createSuccess), actualException);
+	}
+
+	[Fact]
+	[Trait(root, succeed)]
+	public void Succeed_CreateSuccess_SuccessfulResult()
+	{
+		//Arrange
+		const string expectedSuccess = ResultFixture.Success;
+		Func<string> createSuccess = static () => expectedSuccess;
+
+		//Act
+		Result<string, string> actualResult = Result.Succeed<string, string>(createSuccess);
+
+		//Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
+
+	#endregion
 
 	#endregion
 }


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Topic <!-- Required -->

- [x] Feature <!-- Indicates a relationship with a feature or enhancement -->
- [ ] Test <!-- Indicates a relationship with a testing process -->
- [ ] Build <!-- Indicates a relationship with a build process -->
- [ ] Dependency <!-- Indicates a relationship with a development or production dependency -->
- [ ] Bug <!-- Indicates a relationship with a bug or unintended behavior -->
- [ ] Refactor <!-- Indicates a relationship with a refactoring process -->
- [ ] Style <!-- Indicates a relationship with a code style process -->
- [ ] Chore <!-- Indicates a relationship with a maintenance process (does not affect production code) -->
- [ ] Documentation <!-- Indicates a relationship with a documentation process -->
- [ ] Workflow <!-- Indicates a relationship with a CI/CD process -->

## Description <!-- Required -->

Added second overload of the `Succeed` method. The details that make up this action are:

- Summary: Creates a new successful result.
- Signature:

  ```csharp
  public static Result<TFailure, TSuccess> Succeed<TFailure, TSuccess>(Func<TSuccess> createSuccess)
    where TFailure : notnull
    where TSuccess : notnull
  ```

[notnull-constraint]: https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/generics/constraints-on-type-parameters#notnull-constraint

[null-keyword]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/null

- Generics:
  - `TFailure`: Type of possible failure ([notnull][notnull-constraint]).
  - `TSuccess`: Type of expected success ([notnull][notnull-constraint]).
- Parameters:
  - `createSuccess`: Creates the expected success (if `createSuccess` is [null][null-keyword] or its value is [null][null-keyword], [ArgumentNullException](https://learn.microsoft.com/en-us/dotnet/api/system.argumentnullexception?view=net-8.0) will be thrown).

<!-- ## Evidence <!-- Optional -->
