### PR TITLE
workflow: remove redundant `push` event

### DIFF
--- a/.github/workflows/csharp-codeql.yaml
+++ b/.github/workflows/csharp-codeql.yaml
@@ -1,14 +1,5 @@
 name: "C# CodeQL"
 on:
-  push:
-    paths:
-      - "source/**"
-      - "test/**"
-      - ".editorconfig"
-      - "*.props"
-      - "global.json"
-      - "nuget.config"
-      - "*.sln"
   pull_request:
     paths:
       - "source/**"

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,8 +1,5 @@
 name: "Documentation"
 on:
-  push:
-    paths:
-      - "**.md"
   pull_request:
     paths:
       - "**.md"
@@ -17,7 +14,7 @@ env:
 jobs:
   linter:
     name: "Linter"
-    if: "${{ github.event_name == 'push' || github.event_name == 'pull_request' }}"
+    if: "${{ github.event_name == 'pull_request' }}"
     runs-on: "${{ vars.DEFAULT_UBUNTU }}"
     steps:
       - name: "Set up repository with all history"
@@ -37,11 +34,11 @@ jobs:
     name: "Link checker"
     runs-on: "${{ vars.DEFAULT_UBUNTU }}"
     env:
-      IS_PUSH_OR_PULL_REQUEST_EVENT: "${{ github.event_name == 'push' || github.event_name == 'pull_request' }}"
+      IS_PULL_REQUEST_EVENT: "${{ github.event_name == 'pull_request' }}"
       IS_SCHEDULE_OR_WORKFLOW_DISPATCH_EVENT: "${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}"
     steps:
       - name: "Set up repository with all history"
-        if: "${{ env.IS_PUSH_OR_PULL_REQUEST_EVENT == vars.POSITIVE }}"
+        if: "${{ env.IS_PULL_REQUEST_EVENT == vars.POSITIVE }}"
         uses: "actions/checkout@v4.1.1"
         with:
           fetch-depth: 0
@@ -50,12 +47,12 @@ jobs:
         uses: "actions/checkout@v4.1.1"
       - name: "Get all changed files"
         id: "changed-files"
-        if: "${{ env.IS_PUSH_OR_PULL_REQUEST_EVENT == vars.POSITIVE }}"
+        if: "${{ env.IS_PULL_REQUEST_EVENT == vars.POSITIVE }}"
         uses: "tj-actions/changed-files@v40.2.0"
         with:
           files: "${{ env.SEARCH_PATTERN }}"
       - name: "Run link checker for all changed files"
-        if: "${{ env.IS_PUSH_OR_PULL_REQUEST_EVENT == vars.POSITIVE }}"
+        if: "${{ env.IS_PULL_REQUEST_EVENT == vars.POSITIVE }}"
         uses: "lycheeverse/lychee-action@v1.8.0"
         with:
           args: "${{ steps.changed-files.outputs.all_changed_files }}"

--- a/.github/workflows/javascript-codeql.yaml
+++ b/.github/workflows/javascript-codeql.yaml
@@ -1,10 +1,5 @@
 name: "JavaScript CodeQL"
 on:
-  push:
-    paths:
-      - "**.js"
-      - "package.json"
-      - "pnpm-lock.yaml"
   pull_request:
     paths:
       - "**.js"

--- a/.github/workflows/library.yaml
+++ b/.github/workflows/library.yaml
@@ -1,6 +1,8 @@
 name: "Library"
 on:
   push:
+    branches:
+      - "main"
     paths:
       - "source/**"
       - "test/**"
@@ -31,7 +33,7 @@ jobs:
     name: "Builder"
     runs-on: "${{ vars.DEFAULT_UBUNTU }}"
     env:
-      IS_PUSH_EVENT_TO_DEFAULT_BRANCH: "${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}"
+      IS_PUSH_EVENT: "${{ github.event_name == 'push' }}"
       IS_RELEASE: "${{ startsWith(github.ref, 'refs/tags/v') && github.actor == github.repository_owner }}"
       BUILD_CONFIGURATION: "Release"
     steps:
@@ -51,9 +53,9 @@ jobs:
           dotnet test \
             --no-build \
             --configuration '${{ env.BUILD_CONFIGURATION }}' \
-            -property:'CollectCoverage=${{ env.IS_PUSH_EVENT_TO_DEFAULT_BRANCH }}'
+            -property:'CollectCoverage=${{ env.IS_PUSH_EVENT }}'
       - name: "Upload coverage results"
-        if: "${{ env.IS_PUSH_EVENT_TO_DEFAULT_BRANCH == vars.POSITIVE }}"
+        if: "${{ env.IS_PUSH_EVENT == vars.POSITIVE }}"
         uses: "codecov/codecov-action@v3.1.4"
         with:
           directory: "artifacts/coverage"


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Topic <!-- Required -->

- [ ] Feature <!-- Indicates a relationship with a feature or enhancement -->
- [ ] Test <!-- Indicates a relationship with a testing process -->
- [ ] Build <!-- Indicates a relationship with a build process -->
- [ ] Dependency <!-- Indicates a relationship with a development or production dependency -->
- [ ] Bug <!-- Indicates a relationship with a bug or unintended behavior -->
- [ ] Refactor <!-- Indicates a relationship with a refactoring process -->
- [ ] Style <!-- Indicates a relationship with a code style process -->
- [ ] Chore <!-- Indicates a relationship with a maintenance process (does not affect production code) -->
- [ ] Documentation <!-- Indicates a relationship with a documentation process -->
- [x] Workflow <!-- Indicates a relationship with a CI/CD process -->

## Description <!-- Required -->

Removed redundant [push](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore) event.

<!-- ## Evidence <!-- Optional -->
