### PR TITLE
feature: add `Fail` method

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -3,6 +3,26 @@ namespace Daht.Sagitta.Core.Monads;
 /// <summary>Reference point to initialize <see cref="Result{TFailure, TSuccess}"/>.</summary>
 public static class Result
 {
+	/// <summary>Creates a new failed result.</summary>
+	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
+	/// <param name="failure">
+	///     <para>The possible failure.</para>
+	///     <para>If <paramref name="failure"/> is <see langword="null"/>, <seealso cref="ArgumentNullException"/> will be thrown.</para>
+	/// </param>
+	/// <returns>A new failed result.</returns>
+	/// <exception cref="ArgumentNullException"/>
+	public static Result<TFailure, TSuccess> Fail<TFailure, TSuccess>(TFailure failure)
+		where TFailure : notnull
+		where TSuccess : notnull
+		=> failure is null
+			? throw new ArgumentNullException(nameof(failure))
+			: new Result<TFailure, TSuccess>()
+			{
+				IsFailed = true,
+				Failure = failure
+			};
+
 	/// <summary>Creates a new successful result.</summary>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>

--- a/test/unit/Monads/Asserters/ResultAsserter.cs
+++ b/test/unit/Monads/Asserters/ResultAsserter.cs
@@ -2,6 +2,19 @@ namespace Daht.Sagitta.Core.UnitTest.Monads.Asserters;
 
 internal static class ResultAsserter
 {
+	internal static void AreFailed<TFailure, TSuccess>(TFailure expectedFailure, Result<TFailure, TSuccess> actualResult)
+		where TFailure : notnull
+		where TSuccess : notnull
+	{
+		Assert.True(actualResult.IsFailedOrDefault);
+		Assert.False(actualResult.IsSuccessfulOrDefault);
+		Assert.False(actualResult.IsDefault);
+		Assert.True(actualResult.IsFailed);
+		Assert.Equal(expectedFailure, actualResult.Failure);
+		Assert.False(actualResult.IsSuccessful);
+		Assert.Equal(default, actualResult.Success);
+	}
+
 	internal static void AreSuccessful<TFailure, TSuccess>(TSuccess expectedSuccess, Result<TFailure, TSuccess> actualResult)
 		where TFailure : notnull
 		where TSuccess : notnull

--- a/test/unit/Monads/Fixtures/ResultFixture.cs
+++ b/test/unit/Monads/Fixtures/ResultFixture.cs
@@ -2,5 +2,7 @@ namespace Daht.Sagitta.Core.UnitTest.Monads.Fixtures;
 
 internal static class ResultFixture
 {
+	internal const string Failure = nameof(Failure);
+
 	internal const string Success = nameof(Success);
 }

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -6,6 +6,40 @@ public sealed class ResultTest
 
 	private const string succeed = nameof(Result.Succeed);
 
+	private const string fail = nameof(Result.Fail);
+
+	#region Fail
+
+	[Fact]
+	[Trait(root, fail)]
+	public void Fail_NullFailure_ArgumentNullException()
+	{
+		//Arrange
+		const string failure = null!;
+
+		//Act
+		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(static () => _ = Result.Fail<string, string>(failure));
+
+		//Assert
+		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(failure), actualException);
+	}
+
+	[Fact]
+	[Trait(root, fail)]
+	public void Fail_Failure_FailedResult()
+	{
+		//Arrange
+		const string expectedFailure = ResultFixture.Failure;
+
+		//Act
+		Result<string, string> actualResult = Result.Fail<string, string>(expectedFailure);
+
+		//Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	#endregion
+
 	#region Succeed
 
 	#region Overload No. 01


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Topic <!-- Required -->

- [x] Feature <!-- Indicates a relationship with a feature or enhancement -->
- [ ] Test <!-- Indicates a relationship with a testing process -->
- [ ] Build <!-- Indicates a relationship with a build process -->
- [ ] Dependency <!-- Indicates a relationship with a development or production dependency -->
- [ ] Bug <!-- Indicates a relationship with a bug or unintended behavior -->
- [ ] Refactor <!-- Indicates a relationship with a refactoring process -->
- [ ] Style <!-- Indicates a relationship with a code style process -->
- [ ] Chore <!-- Indicates a relationship with a maintenance process (does not affect production code) -->
- [ ] Documentation <!-- Indicates a relationship with a documentation process -->
- [ ] Workflow <!-- Indicates a relationship with a CI/CD process -->

## Description <!-- Required -->

Added `Fail` method. The details that make up this action are:

- Summary: Creates a new failed result.
- Signature:

  ```csharp
  public static Result<TFailure, TSuccess> Fail<TFailure, TSuccess>(TFailure failure)
    where TFailure : notnull
    where TSuccess : notnull
  ```

[notnull-constraint]: https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/generics/constraints-on-type-parameters#notnull-constraint

- Generics:
  - `TFailure`: Type of possible failure ([notnull][notnull-constraint]).
  - `TSuccess`: Type of expected success ([notnull][notnull-constraint]).
- Parameters:
  - `failure`: The possible failure (if `failure` is [null](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/null), [ArgumentNullException](https://learn.microsoft.com/en-us/dotnet/api/system.argumentnullexception?view=net-8.0) will be thrown).

<!-- ## Evidence <!-- Optional -->
