### PR TITLE
feature: add second overload of the `Fail` method

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -6,6 +6,24 @@ public static class Result
 	/// <summary>Creates a new failed result.</summary>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
+	/// <param name="createFailure">
+	///     <para>Creates the possible failure.</para>
+	///     <para>If <paramref name="createFailure"/> is <see langword="null"/> or its value is <see langword="null"/>, <seealso cref="ArgumentNullException"/> will be thrown.</para>
+	/// </param>
+	/// <returns>A new failed result.</returns>
+	/// <exception cref="ArgumentNullException"/>
+	public static Result<TFailure, TSuccess> Fail<TFailure, TSuccess>(Func<TFailure> createFailure)
+		where TFailure : notnull
+		where TSuccess : notnull
+	{
+		ArgumentNullException.ThrowIfNull(createFailure);
+		TFailure failure = createFailure() ?? throw new ArgumentNullException(nameof(createFailure));
+		return Fail<TFailure, TSuccess>(failure);
+	}
+
+	/// <summary>Creates a new failed result.</summary>
+	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <param name="failure">
 	///     <para>The possible failure.</para>
 	///     <para>If <paramref name="failure"/> is <see langword="null"/>, <seealso cref="ArgumentNullException"/> will be thrown.</para>

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -10,6 +10,8 @@ public sealed class ResultTest
 
 	#region Fail
 
+	#region Overload No. 01
+
 	[Fact]
 	[Trait(root, fail)]
 	public void Fail_NullFailure_ArgumentNullException()
@@ -37,6 +39,55 @@ public sealed class ResultTest
 		//Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
+
+	#endregion
+
+	#region Overload No. 02
+
+	[Fact]
+	[Trait(root, fail)]
+	public void Fail_NullCreateFailure_ArgumentNullException()
+	{
+		//Arrange
+		const Func<string> createFailure = null!;
+
+		//Act
+		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(static () => _ = Result.Fail<string, string>(createFailure));
+
+		//Assert
+		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(createFailure), actualException);
+	}
+
+	[Fact]
+	[Trait(root, fail)]
+	public void Fail_CreateFailureWithNullValue_ArgumentNullException()
+	{
+		//Arrange
+		Func<string> createFailure = static () => null!;
+
+		//Act
+		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(() => _ = Result.Fail<string, string>(createFailure));
+
+		//Assert
+		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(createFailure), actualException);
+	}
+
+	[Fact]
+	[Trait(root, fail)]
+	public void Fail_CreateFailure_FailedResult()
+	{
+		//Arrange
+		const string expectedFailure = ResultFixture.Failure;
+		Func<string> createFailure = static () => expectedFailure;
+
+		//Act
+		Result<string, string> actualResult = Result.Fail<string, string>(createFailure);
+
+		//Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	#endregion
 
 	#endregion
 


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Topic <!-- Required -->

- [x] Feature <!-- Indicates a relationship with a feature or enhancement -->
- [ ] Test <!-- Indicates a relationship with a testing process -->
- [ ] Build <!-- Indicates a relationship with a build process -->
- [ ] Dependency <!-- Indicates a relationship with a development or production dependency -->
- [ ] Bug <!-- Indicates a relationship with a bug or unintended behavior -->
- [ ] Refactor <!-- Indicates a relationship with a refactoring process -->
- [ ] Style <!-- Indicates a relationship with a code style process -->
- [ ] Chore <!-- Indicates a relationship with a maintenance process (does not affect production code) -->
- [ ] Documentation <!-- Indicates a relationship with a documentation process -->
- [ ] Workflow <!-- Indicates a relationship with a CI/CD process -->

## Description <!-- Required -->

Added second overload of the `Fail` method. The details that make up this action are:

- Summary: Creates a new failed result.
- Signature:

  ```csharp
  public static Result<TFailure, TSuccess> Fail<TFailure, TSuccess>(Func<TFailure> createFailure)
    where TFailure : notnull
    where TSuccess : notnull
  ```

[notnull-constraint]: https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/generics/constraints-on-type-parameters#notnull-constraint

[null-keyword]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/null

- Generics:
  - `TFailure`: Type of possible failure ([notnull][notnull-constraint]).
  - `TSuccess`: Type of expected success ([notnull][notnull-constraint]).
- Parameters:
  - `createFailure`: Creates the possible failure (if `createFailure` is [null][null-keyword] or its value is [null][null-keyword], [ArgumentNullException](https://learn.microsoft.com/en-us/dotnet/api/system.argumentnullexception?view=net-8.0) will be thrown).

<!-- ## Evidence <!-- Optional -->
