### PR TITLE
feature: add `Ensure` method

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -3,6 +3,23 @@ namespace Daht.Sagitta.Core.Monads;
 /// <summary>Reference point to initialize <see cref="Result{TFailure, TSuccess}"/>.</summary>
 public static class Result
 {
+	/// <summary>Creates a new failed result if <paramref name="success"/> is <see langword="null"/>; otherwise, creates a new successful result.</summary>
+	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
+	/// <param name="success">The expected success.</param>
+	/// <param name="failure">
+	///		<para>The possible failure.</para>
+	///     <para>If <paramref name="failure"/> is <see langword="null"/>, <seealso cref="ArgumentNullException"/> will be thrown.</para>
+	/// </param>
+	/// <returns>A new failed result if <paramref name="success"/> is <see langword="null"/>; otherwise, a new successful result.</returns>
+	/// <exception cref="ArgumentNullException"/>
+	public static Result<TFailure, TSuccess> Ensure<TFailure, TSuccess>(TSuccess? success, TFailure failure)
+		where TFailure : notnull
+		where TSuccess : notnull
+		=> success is null
+			? Fail<TFailure, TSuccess>(failure)
+			: Succeed<TFailure, TSuccess>(success);
+
 	/// <summary>Creates a new failed result if the value of <paramref name="createSuccess"/> throws <typeparamref name="TException"/>; otherwise, creates a new successful result.</summary>
 	/// <typeparam name="TException">Type of possible exception.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -4,11 +4,62 @@ public sealed class ResultTest
 {
 	private const string root = nameof(Result);
 
+	private const string ensure = nameof(Result.Ensure);
+
 	private const string @catch = nameof(Result.Catch);
 
 	private const string fail = nameof(Result.Fail);
 
 	private const string succeed = nameof(Result.Succeed);
+
+	#region Ensure
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_NullSuccessPlusNullFailure_ArgumentNullException()
+	{
+		//Arrange
+		const string success = null!;
+		const string failure = null!;
+
+		//Act
+		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(static () => _ = Result.Ensure(success, failure));
+
+		//Assert
+		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(failure), actualException);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_NullSuccessPlusFailure_FailedResult()
+	{
+		//Arrange
+		const string success = null!;
+		const string expectedFailure = ResultFixture.Failure;
+
+		//Act
+		Result<string, string> actualResult = Result.Ensure(success, expectedFailure);
+
+		//Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_SuccessPlusFailure_SuccessfulResult()
+	{
+		//Arrange
+		const string expectedSuccess = ResultFixture.Success;
+		const string failure = ResultFixture.Failure;
+
+		//Act
+		Result<string, string> actualResult = Result.Ensure(expectedSuccess, failure);
+
+		//Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
+
+	#endregion
 
 	#region Catch
 


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Topic <!-- Required -->

- [x] Feature <!-- Indicates a relationship with a feature or enhancement -->
- [ ] Test <!-- Indicates a relationship with a testing process -->
- [ ] Build <!-- Indicates a relationship with a build process -->
- [ ] Dependency <!-- Indicates a relationship with a development or production dependency -->
- [ ] Bug <!-- Indicates a relationship with a bug or unintended behavior -->
- [ ] Refactor <!-- Indicates a relationship with a refactoring process -->
- [ ] Style <!-- Indicates a relationship with a code style process -->
- [ ] Chore <!-- Indicates a relationship with a maintenance process (does not affect production code) -->
- [ ] Documentation <!-- Indicates a relationship with a documentation process -->
- [ ] Workflow <!-- Indicates a relationship with a CI/CD process -->

## Description <!-- Required -->

Added `Ensure` method. The details that make up this action are:

[null-keyword]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/null

- Summary: Creates a new failed result if `success` is [null][null-keyword]; otherwise, creates a new successful result.
- Signature:

  ```csharp
  public static Result<TFailure, TSuccess> Ensure<TFailure, TSuccess>(TSuccess? success, TFailure failure)
    where TFailure : notnull
    where TSuccess : notnull
  ```

[notnull-constraint]: https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/generics/constraints-on-type-parameters#notnull-constraint
[argument-null-exception]: https://learn.microsoft.com/en-us/dotnet/api/system.argumentnullexception?view=net-8.0

- Generics:
  - `TFailure`: Type of possible failure ([notnull][notnull-constraint]).
  - `TSuccess`: Type of expected success ([notnull][notnull-constraint]).
- Parameters:
  - `success`: The expected success.
  - `failure`: The possible failure (if `failure` is [null][null-keyword], [ArgumentNullException][argument-null-exception] will be thrown).

<!-- ## Evidence <!-- Optional -->
