### PR TITLE
feature: add second overload of the `Ensure` method

### DIFF
--- a/Sagitta.sln
+++ b/Sagitta.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.8.34322.80
+VisualStudioVersion = 17.8.34330.188
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core", "Core", "{D4223882-8D25-49B3-9299-A680AFD6D275}"
 EndProject

--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -20,6 +20,23 @@ public static class Result
 			? Fail<TSuccess, TFailure>(failure)
 			: Succeed<TSuccess, TFailure>(success);
 
+	/// <summary>Creates a new failed result if <paramref name="success"/> is <see langword="null"/>; otherwise, creates a new successful result.</summary>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
+	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <param name="success">The expected success.</param>
+	/// <param name="createFailure">
+	///     <para>Creates the possible failure.</para>
+	///     <para>If <paramref name="createFailure"/> is <see langword="null"/> or its value is <see langword="null"/>, <seealso cref="ArgumentNullException"/> will be thrown.</para>
+	/// </param>
+	/// <returns>A new failed result if <paramref name="success"/> is <see langword="null"/>; otherwise, a new successful result.</returns>
+	///	<exception cref="ArgumentNullException"/>
+	public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(TSuccess? success, Func<TFailure> createFailure)
+		where TSuccess : notnull
+		where TFailure : notnull
+		=> success is null
+			? Fail<TSuccess, TFailure>(createFailure)
+			: Succeed<TSuccess, TFailure>(success);
+
 	/// <summary>Creates a new failed result if the value of <paramref name="createSuccess"/> throws <typeparamref name="TException"/>; otherwise, creates a new successful result.</summary>
 	/// <typeparam name="TException">Type of possible exception.</typeparam>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -14,6 +14,8 @@ public sealed class ResultTest
 
 	#region Ensure
 
+	#region Overload No. 01
+
 	[Fact]
 	[Trait(root, ensure)]
 	public void Ensure_NullSuccessPlusNullFailure_ArgumentNullException()
@@ -58,6 +60,73 @@ public sealed class ResultTest
 		//Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
 	}
+
+	#endregion
+
+	#region Overload No. 02
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_NullSuccessPlusNullCreateFailure_ArgumentNullException()
+	{
+		//Arrange
+		const string success = null!;
+		const Func<string> createFailure = null!;
+
+		//Act
+		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(static () => _ = Result.Ensure(success, createFailure));
+
+		//Assert
+		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(createFailure), actualException);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_NullSuccessPlusCreateFailureWithNullValue_ArgumentNullException()
+	{
+		//Arrange
+		const string success = null!;
+		Func<string> createFailure = static () => null!;
+
+		//Act
+		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(() => _ = Result.Ensure(success, createFailure));
+
+		//Assert
+		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(createFailure), actualException);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_NullSuccessPlusCreateFailure_FailedResult()
+	{
+		//Arrange
+		const string? success = null;
+		const string expectedFailure = ResultFixture.Failure;
+		Func<string> createFailure = static () => expectedFailure;
+
+		//Act
+		Result<string, string> actualResult = Result.Ensure(success, createFailure);
+
+		//Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_SuccessPlusCreateFailure_SuccessfulResult()
+	{
+		//Arrange
+		const string expectedSuccess = ResultFixture.Success;
+		Func<string> createFailure = static () => ResultFixture.Failure;
+
+		//Act
+		Result<string, string> actualResult = Result.Ensure(expectedSuccess, createFailure);
+
+		//Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
+
+	#endregion
 
 	#endregion
 


### PR DESCRIPTION
[null-keyword]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/null
[notnull-constraint]: https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/generics/constraints-on-type-parameters#notnull-constraint
[argument-null-exception]: https://learn.microsoft.com/en-us/dotnet/api/system.argumentnullexception?view=net-8.0

<!-- ## Ticket(s) <!-- Optional -->

## Topic <!-- Required -->

- [x] Feature <!-- Indicates a relationship with a feature or enhancement -->
- [ ] Test <!-- Indicates a relationship with a testing process -->
- [ ] Build <!-- Indicates a relationship with a build process -->
- [ ] Dependency <!-- Indicates a relationship with a development or production dependency -->
- [ ] Bug <!-- Indicates a relationship with a bug or unintended behavior -->
- [ ] Refactor <!-- Indicates a relationship with a refactoring process -->
- [ ] Style <!-- Indicates a relationship with a code style process -->
- [ ] Chore <!-- Indicates a relationship with a maintenance process (does not affect production code) -->
- [ ] Documentation <!-- Indicates a relationship with a documentation process -->
- [ ] Workflow <!-- Indicates a relationship with a CI/CD process -->

## Description <!-- Required -->

Added second overload of the `Ensure` method. The details that make up this action are:

- Summary: Creates a new failed result if `success` is [null][null-keyword]; otherwise, creates a new successful result.
- Signature:

  ```csharp
  public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(TSuccess? success, Func<TFailure> createFailure)
    where TSuccess : notnull
    where TFailure : notnull
  ```

- Generics:
  - `TSuccess`: Type of expected success ([notnull][notnull-constraint]).
  - `TFailure`: Type of possible failure ([notnull][notnull-constraint]).
- Parameters:
  - `success`: The expected success.
  - `createFailure`: Creates the possible failure (if `createFailure` is [null][null-keyword] or its value is [null][null-keyword], [ArgumentNullException][argument-null-exception] will be thrown).
- Exceptions:
  - [ArgumentNullException][argument-null-exception].

<!-- ## Evidence <!-- Optional -->
