### PR TITLE
feature: add third overload of the `Ensure` method

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -37,6 +37,30 @@ public static class Result
 			? Fail<TSuccess, TFailure>(createFailure)
 			: Succeed<TSuccess, TFailure>(success);
 
+	/// <summary>Creates a new failed result if the value of <paramref name="createSuccess"/> is <see langword="null"/>; otherwise, creates a new successful result.</summary>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
+	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <param name="createSuccess">
+	///     <para>Creates the expected success.</para>
+	///     <para>If <paramref name="createSuccess"/> is <see langword="null"/>, <seealso cref="ArgumentNullException"/> will be thrown.</para>
+	/// </param>
+	/// <param name="failure">
+	///		<para>The possible failure.</para>
+	///     <para>If <paramref name="failure"/> is <see langword="null"/>, <seealso cref="ArgumentNullException"/> will be thrown.</para>
+	/// </param>
+	/// <returns>A new failed result if the value of <paramref name="createSuccess"/> is <see langword="null"/>; otherwise, a new successful result.</returns>
+	///	<exception cref="ArgumentNullException"/>
+	public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(Func<TSuccess?> createSuccess, TFailure failure)
+		where TSuccess : notnull
+		where TFailure : notnull
+	{
+		ArgumentNullException.ThrowIfNull(createSuccess);
+		TSuccess? success = createSuccess();
+		return success is null
+			? Fail<TSuccess, TFailure>(failure)
+			: Succeed<TSuccess, TFailure>(success);
+	}
+
 	/// <summary>Creates a new failed result if the value of <paramref name="createSuccess"/> throws <typeparamref name="TException"/>; otherwise, creates a new successful result.</summary>
 	/// <typeparam name="TException">Type of possible exception.</typeparam>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -128,6 +128,71 @@ public sealed class ResultTest
 
 	#endregion
 
+	#region Overload No. 03
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_NullCreateSuccessPlusFailure_ArgumentNullException()
+	{
+		//Arrange
+		const Func<string> createSuccess = null!;
+		const string failure = ResultFixture.Failure;
+
+		//Act
+		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(static () => _ = Result.Ensure(createSuccess, failure));
+
+		//Assert
+		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(createSuccess), actualException);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_CreateSuccessWithNullValuePlusNullFailure_ArgumentNullException()
+	{
+		//Arrange
+		Func<string?> createSuccess = static () => null;
+		const string failure = null!;
+
+		//Act
+		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(() => _ = Result.Ensure(createSuccess, failure));
+
+		//Assert
+		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(failure), actualException);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_CreateSuccessWithNullValuePlusFailure_FailedResult()
+	{
+		//Arrange
+		Func<string?> createSuccess = static () => null;
+		const string expectedFailure = ResultFixture.Failure;
+
+		//Act
+		Result<string, string> actualResult = Result.Ensure(createSuccess, expectedFailure);
+
+		//Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_CreateSuccessPlusFailure_SuccessfulResult()
+	{
+		//Arrange
+		const string expectedSuccess = ResultFixture.Success;
+		Func<string> createSuccess = static () => expectedSuccess;
+		const string failure = ResultFixture.Failure;
+
+		//Act
+		Result<string, string> actualResult = Result.Ensure(createSuccess, failure);
+
+		//Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
+
+	#endregion
+
 	#endregion
 
 	#region Catch


### PR DESCRIPTION
[null-keyword]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/null
[notnull-constraint]: https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/generics/constraints-on-type-parameters#notnull-constraint
[argument-null-exception]: https://learn.microsoft.com/en-us/dotnet/api/system.argumentnullexception?view=net-8.0

<!-- ## Ticket(s) <!-- Optional -->

## Topic <!-- Required -->

- [x] Feature <!-- Indicates a relationship with a feature or enhancement -->
- [ ] Test <!-- Indicates a relationship with a testing process -->
- [ ] Build <!-- Indicates a relationship with a build process -->
- [ ] Dependency <!-- Indicates a relationship with a development or production dependency -->
- [ ] Bug <!-- Indicates a relationship with a bug or unintended behavior -->
- [ ] Refactor <!-- Indicates a relationship with a refactoring process -->
- [ ] Style <!-- Indicates a relationship with a code style process -->
- [ ] Chore <!-- Indicates a relationship with a maintenance process (does not affect production code) -->
- [ ] Documentation <!-- Indicates a relationship with a documentation process -->
- [ ] Workflow <!-- Indicates a relationship with a CI/CD process -->

## Description <!-- Required -->

Added third overload of the `Ensure` method. The details that make up this action are:

- Summary: Creates a new failed result if the value of `createSuccess` is [null][null-keyword]; otherwise, creates a new successful result.
- Signature:

  ```cs
  public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(Func<TSuccess?> createSuccess, TFailure failure)
    where TSuccess : notnull
    where TFailure : notnull
  ```

- Generics:
  - `TSuccess`: Type of expected success ([notnull][notnull-constraint]).
  - `TFailure`: Type of possible failure ([notnull][notnull-constraint]).
- Parameters:
  - `createSuccess`: Creates the expected success (if `createSuccess` is [null][null-keyword], [ArgumentNullException][argument-null-exception] will be thrown).
  - `failure`: The possible failure (if `failure` is [null][null-keyword], [ArgumentNullException][argument-null-exception] will be thrown).
- Exceptions:
  - [ArgumentNullException][argument-null-exception].

<!-- ## Evidence <!-- Optional -->
