### PR TITLE
feature: add fourth overload of the `Ensure` method

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -61,6 +61,30 @@ public static class Result
 			: Succeed<TSuccess, TFailure>(success);
 	}
 
+	/// <summary>Creates a new failed result if the value of <paramref name="createSuccess"/> is <see langword="null"/>; otherwise, creates a new successful result.</summary>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
+	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <param name="createSuccess">
+	///     <para>Creates the expected success.</para>
+	///     <para>If <paramref name="createSuccess"/> is <see langword="null"/>, <seealso cref="ArgumentNullException"/> will be thrown.</para>
+	/// </param>
+	/// <param name="createFailure">
+	///     <para>Creates the possible failure.</para>
+	///     <para>If <paramref name="createFailure"/> is <see langword="null"/> or its value is <see langword="null"/>, <seealso cref="ArgumentNullException"/> will be thrown.</para>
+	/// </param>
+	/// <returns>A new failed result if the value of <paramref name="createSuccess"/> is <see langword="null"/>; otherwise, a new successful result.</returns>
+	/// <exception cref="ArgumentNullException"/>
+	public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(Func<TSuccess?> createSuccess, Func<TFailure> createFailure)
+		where TSuccess : notnull
+		where TFailure : notnull
+	{
+		ArgumentNullException.ThrowIfNull(createSuccess);
+		TSuccess? success = createSuccess();
+		return success is null
+			? Fail<TSuccess, TFailure>(createFailure)
+			: Succeed<TSuccess, TFailure>(success);
+	}
+
 	/// <summary>Creates a new failed result if the value of <paramref name="createSuccess"/> throws <typeparamref name="TException"/>; otherwise, creates a new successful result.</summary>
 	/// <typeparam name="TException">Type of possible exception.</typeparam>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -193,6 +193,87 @@ public sealed class ResultTest
 
 	#endregion
 
+	#region Overload No. 04
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_NullCreateSuccessPlusCreateFailure_ArgumentNullException()
+	{
+		//Arrange
+		const Func<string> createSuccess = null!;
+		Func<string> createFailure = static () => ResultFixture.Failure;
+
+		//Act
+		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(() => _ = Result.Ensure(createSuccess, createFailure));
+
+		//Assert
+		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(createSuccess), actualException);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_CreateSuccessWithNullValuePlusNullCreateFailure_ArgumentNullException()
+	{
+		//Arrange
+		Func<string?> createSuccess = static () => null;
+		const Func<string> createFailure = null!;
+
+		//Act
+		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(() => _ = Result.Ensure(createSuccess, createFailure));
+
+		//Assert
+		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(createFailure), actualException);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_CreateSuccessWithNullValuePlusCreateFailureWithNullValue_ArgumentNullException()
+	{
+		//Arrange
+		Func<string?> createSuccess = static () => null;
+		Func<string> createFailure = static () => null!;
+
+		//Act
+		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(() => _ = Result.Ensure(createSuccess, createFailure));
+
+		//Assert
+		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(createFailure), actualException);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_CreateSuccessWithNullValuePlusCreateFailure_FailedResult()
+	{
+		//Arrange
+		Func<string?> createSuccess = static () => null;
+		const string expectedFailure = ResultFixture.Failure;
+		Func<string> createFailure = static () => expectedFailure;
+
+		//Act
+		Result<string, string> actualResult = Result.Ensure(createSuccess, createFailure);
+
+		//Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_CreateSuccessPlusCreateFailure_SuccessfulResult()
+	{
+		//Arrange
+		const string expectedSuccess = ResultFixture.Success;
+		Func<string> createSuccess = static () => expectedSuccess;
+		Func<string> createFailure = static () => ResultFixture.Failure;
+
+		//Act
+		Result<string, string> actualResult = Result.Ensure(createSuccess, createFailure);
+
+		//Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
+
+	#endregion
+
 	#endregion
 
 	#region Catch


### PR DESCRIPTION
[null-keyword]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/null
[notnull-constraint]: https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/generics/constraints-on-type-parameters#notnull-constraint
[argument-null-exception]: https://learn.microsoft.com/en-us/dotnet/api/system.argumentnullexception?view=net-8.0

<!-- ## Ticket(s) <!-- Optional -->

## Topic <!-- Required -->

- [x] Feature <!-- Indicates a relationship with a feature or enhancement -->
- [ ] Test <!-- Indicates a relationship with a testing process -->
- [ ] Build <!-- Indicates a relationship with a build process -->
- [ ] Dependency <!-- Indicates a relationship with a development or production dependency -->
- [ ] Bug <!-- Indicates a relationship with a bug or unintended behavior -->
- [ ] Refactor <!-- Indicates a relationship with a refactoring process -->
- [ ] Style <!-- Indicates a relationship with a code style process -->
- [ ] Chore <!-- Indicates a relationship with a maintenance process (does not affect production code) -->
- [ ] Documentation <!-- Indicates a relationship with a documentation process -->
- [ ] Workflow <!-- Indicates a relationship with a CI/CD process -->

## Description <!-- Required -->

Added fourth overload of the `Ensure` method. The details that make up this action are:

- Type: [Result](source/Monads/Result.cs).
- Signature:

  ```cs
  public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(Func<TSuccess?> createSuccess, Func<TFailure> createFailure)
    where TSuccess : notnull
    where TFailure : notnull
  ```

- Summary: Creates a new failed result if the value of `createSuccess` is [null][null-keyword]; otherwise, creates a new successful result.
- Generics:
  - `TSuccess`: Type of expected success ([notnull][notnull-constraint]).
  - `TFailure`: Type of possible failure ([notnull][notnull-constraint]).
- Parameters:
  - `createSuccess`: Creates the expected success (if `createSuccess` is [null][null-keyword], [ArgumentNullException][argument-null-exception] will be thrown).
  - `createFailure`: Creates the possible failure (if `createFailure` is [null][null-keyword] or its value is [null][null-keyword], [ArgumentNullException][argument-null-exception] will be thrown).
- Exceptions:
  - [ArgumentNullException][argument-null-exception].

<!-- ## Evidence <!-- Optional -->
