### PR TITLE
feature: add second overload of the implicit operator

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -234,4 +234,14 @@ public readonly record struct Result<TSuccess, TFailure>
 	/// <exception cref="ArgumentNullException"/>
 	public static implicit operator Result<TSuccess, TFailure>(TSuccess success)
 		=> Result.Succeed<TSuccess, TFailure>(success);
+
+	/// <summary>Creates a new successful result.</summary>
+	/// <param name="createSuccess">
+	///     <para>Creates the expected success.</para>
+	///     <para>If <paramref name="createSuccess"/> is <see langword="null"/> or its value is <see langword="null"/>, <seealso cref="ArgumentNullException"/> will be thrown.</para>
+	/// </param>
+	/// <returns>A new successful result.</returns>
+	/// <exception cref="ArgumentNullException"/>
+	public static implicit operator Result<TSuccess, TFailure>(Func<TSuccess> createSuccess)
+		=> Result.Succeed<TSuccess, TFailure>(createSuccess);
 }

--- a/source/Sagitta.Core.csproj
+++ b/source/Sagitta.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<NoWarn>$(NoWarn),CA2225</NoWarn>
+		<NoWarn>$(NoWarn); CA2225</NoWarn>
 		<IsPackable>true</IsPackable>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 		<EnablePackageValidation>true</EnablePackageValidation>

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -578,6 +578,8 @@ public sealed class ResultTest
 
 	#region Implicit Operator
 
+	#region Overload No. 01
+
 	[Fact]
 	[Trait(root, implicitOperator)]
 	public void ImplicitOperator_NullSuccess_ArgumentNullException()
@@ -611,6 +613,69 @@ public sealed class ResultTest
 		//Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
 	}
+
+	#endregion
+
+	#region Overload No. 02
+
+	[Fact]
+	[Trait(root, implicitOperator)]
+	public void ImplicitOperator_NullCreateSuccess_ArgumentNullException()
+	{
+		//Arrange
+		const Func<Constellation> createSuccess = null!;
+
+		//Act
+		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(
+			static () =>
+			{
+#pragma warning disable S1481
+				Result<Constellation, string> _ = createSuccess;
+#pragma warning restore S1481
+			}
+		);
+
+		//Assert
+		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(createSuccess), actualException);
+	}
+
+	[Fact]
+	[Trait(root, implicitOperator)]
+	public void ImplicitOperator_CreateSuccessWithNullValue_ArgumentNullException()
+	{
+		//Arrange
+		Func<Constellation> createSuccess = static () => null!;
+
+		//Act
+		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(
+			() =>
+			{
+#pragma warning disable S1481
+				Result<Constellation, string> _ = createSuccess;
+#pragma warning restore S1481
+			}
+		);
+
+		//Assert
+		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(createSuccess), actualException);
+	}
+
+	[Fact]
+	[Trait(root, implicitOperator)]
+	public void ImplicitOperator_CreateSuccess_SuccessfulResult()
+	{
+		//Arrange
+		Constellation expectedSuccess = ResultFixture.Success;
+		Func<Constellation> createSuccess = () => expectedSuccess;
+
+		//Act
+		Result<Constellation, string> actualResult = createSuccess;
+
+		//Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
+
+	#endregion
 
 	#endregion
 }


### PR DESCRIPTION
[null-keyword]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/null
[argument-null-exception]: https://learn.microsoft.com/en-us/dotnet/api/system.argumentnullexception?view=net-8.0

<!-- ## Ticket(s) <!-- Optional -->

## Topic <!-- Required -->

- [x] Feature <!-- Indicates a relationship with a feature or enhancement -->
- [ ] Test <!-- Indicates a relationship with a testing process -->
- [ ] Build <!-- Indicates a relationship with a build process -->
- [ ] Dependency <!-- Indicates a relationship with a development or production dependency -->
- [ ] Bug <!-- Indicates a relationship with a bug or unintended behavior -->
- [ ] Refactor <!-- Indicates a relationship with a refactoring process -->
- [ ] Style <!-- Indicates a relationship with a code style process -->
- [ ] Chore <!-- Indicates a relationship with a maintenance process (does not affect production code) -->
- [ ] Documentation <!-- Indicates a relationship with a documentation process -->
- [ ] Workflow <!-- Indicates a relationship with a CI/CD process -->

## Description <!-- Required -->

Added second overload of the [implicit operator](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/user-defined-conversion-operators). The details that make up this action are:

- Type: [Result<TSuccess, TFailure>](source/Monads/Result.cs).
- Signature:

  ```cs
  public static implicit operator Result<TSuccess, TFailure>(Func<TSuccess> createSuccess)
  ```

- Summary: Creates a new successful result.
- Parameters:
  - `createSuccess`: Creates the expected success (if `createSuccess` is [null][null-keyword] or its value is [null][null-keyword], [ArgumentNullException][argument-null-exception] will be thrown).
- Exceptions:
  - [ArgumentNullException][argument-null-exception].

<!-- ## Evidence <!-- Optional -->
