### PR TITLE
feature: add third overload of the implicit operator

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -244,4 +244,14 @@ public readonly record struct Result<TSuccess, TFailure>
 	/// <exception cref="ArgumentNullException"/>
 	public static implicit operator Result<TSuccess, TFailure>(Func<TSuccess> createSuccess)
 		=> Result.Succeed<TSuccess, TFailure>(createSuccess);
+
+	/// <summary>Creates a new failed result.</summary>
+	/// <param name="failure">
+	///     <para>The possible failure.</para>
+	///     <para>If <paramref name="failure"/> is <see langword="null"/>, <seealso cref="ArgumentNullException"/> will be thrown.</para>
+	/// </param>
+	/// <returns>A new failed result.</returns>
+	/// <exception cref="ArgumentNullException"/>
+	public static implicit operator Result<TSuccess, TFailure>(TFailure failure)
+		=> Result.Fail<TSuccess, TFailure>(failure);
 }

--- a/source/Sagitta.Core.csproj
+++ b/source/Sagitta.Core.csproj
@@ -10,7 +10,7 @@
 		<Description>Functional paradigm abstractions | Core</Description>
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
-		<PackageTags>$(Company); Sagitta; Functional; Result</PackageTags>
+		<PackageTags>$(Company); Sagitta; Functional-paradigm; Result</PackageTags>
 		<NeutralLanguage>en-US</NeutralLanguage>
 		<RepositoryType>git</RepositoryType>
 		<RepositoryUrl>https://github.com/daht-x/sagitta-core</RepositoryUrl>

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -677,5 +677,44 @@ public sealed class ResultTest
 
 	#endregion
 
+	#region Overload No. 03
+
+	[Fact]
+	[Trait(root, implicitOperator)]
+	public void ImplicitOperator_NullFailure_ArgumentNullException()
+	{
+		//Arrange
+		const string failure = null!;
+
+		//Act
+		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(
+			static () =>
+			{
+#pragma warning disable S1481
+				Result<Constellation, string> _ = failure;
+#pragma warning restore S1481
+			}
+		);
+
+		//Assert
+		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(failure), actualException);
+	}
+
+	[Fact]
+	[Trait(root, implicitOperator)]
+	public void ImplicitOperator_Failure_FailedResult()
+	{
+		//Arrange
+		const string expectedFailure = ResultFixture.Failure;
+
+		//Act
+		Result<Constellation, string> actualResult = expectedFailure;
+
+		//Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	#endregion
+
 	#endregion
 }


### PR DESCRIPTION
[argument-null-exception]: https://learn.microsoft.com/en-us/dotnet/api/system.argumentnullexception?view=net-8.0

<!-- ## Ticket(s) <!-- Optional -->

## Topic <!-- Required -->

- [x] Feature <!-- Indicates a relationship with a feature or enhancement -->
- [ ] Test <!-- Indicates a relationship with a testing process -->
- [ ] Build <!-- Indicates a relationship with a build process -->
- [ ] Dependency <!-- Indicates a relationship with a development or production dependency -->
- [ ] Bug <!-- Indicates a relationship with a bug or unintended behavior -->
- [ ] Refactor <!-- Indicates a relationship with a refactoring process -->
- [ ] Style <!-- Indicates a relationship with a code style process -->
- [ ] Chore <!-- Indicates a relationship with a maintenance process (does not affect production code) -->
- [ ] Documentation <!-- Indicates a relationship with a documentation process -->
- [ ] Workflow <!-- Indicates a relationship with a CI/CD process -->

## Description <!-- Required -->

Added third overload of the [implicit operator](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/user-defined-conversion-operators). The details that make up this action are:

- Type: [Result<TSuccess, TFailure>](source/Monads/Result.cs).
- Signature:

  ```cs
  public static implicit operator Result<TSuccess, TFailure>(TFailure failure)
  ```

- Summary: Creates a new failed result.
- Parameters:
  - `failure`: The possible failure (if `failure` is [null](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/null), [ArgumentNullException][argument-null-exception] will be thrown).
- Exceptions:
  - [ArgumentNullException][argument-null-exception].

<!-- ## Evidence <!-- Optional -->
