### PR TITLE
feature: add fourth overload of the implicit operator

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -254,4 +254,15 @@ public readonly record struct Result<TSuccess, TFailure>
 	/// <exception cref="ArgumentNullException"/>
 	public static implicit operator Result<TSuccess, TFailure>(TFailure failure)
 		=> Result.Fail<TSuccess, TFailure>(failure);
+
+	/// <summary>Creates a new failed result.</summary>
+	/// <param name="createFailure">
+	///     <para>Creates the possible failure.</para>
+	///     <para>If <paramref name="createFailure"/> is <see langword="null"/> or its value is <see langword="null"/>, <seealso cref="ArgumentNullException"/> will be thrown.</para>
+	/// </param>
+	/// <returns>A new failed result.</returns>
+	/// <exception cref="ArgumentNullException"/>
+	/// <exception cref="ArgumentNullException"/>
+	public static implicit operator Result<TSuccess, TFailure>(Func<TFailure> createFailure)
+		=> Result.Fail<TSuccess, TFailure>(createFailure);
 }

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -716,5 +716,66 @@ public sealed class ResultTest
 
 	#endregion
 
+	#region Overload No. 04
+
+	[Fact]
+	[Trait(root, implicitOperator)]
+	public void ImplicitOperator_NullCreateFailure_ArgumentNullException()
+	{
+		//Arrange
+		const Func<string> createFailure = null!;
+
+		//Act
+		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(
+			static () =>
+			{
+#pragma warning disable S1481
+				Result<Constellation, string> _ = createFailure;
+#pragma warning restore S1481
+			}
+		);
+
+		//Assert
+		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(createFailure), actualException);
+	}
+
+	[Fact]
+	[Trait(root, implicitOperator)]
+	public void ImplicitOperator_CreateFailureWithNullValue_ArgumentNullException()
+	{
+		//Arrange
+		Func<string> createFailure = static () => null!;
+
+		//Act
+		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(
+			() =>
+			{
+#pragma warning disable S1481
+				Result<Constellation, string> _ = createFailure;
+#pragma warning restore S1481
+			}
+		);
+
+		//Assert
+		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(createFailure), actualException);
+	}
+
+	[Fact]
+	[Trait(root, implicitOperator)]
+	public void ImplicitOperator_CreateFailure_FailedResult()
+	{
+		//Arrange
+		const string expectedFailure = ResultFixture.Failure;
+		Func<string> createFailure = static () => expectedFailure;
+
+		//Act
+		Result<Constellation, string> actualResult = createFailure;
+
+		//Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	#endregion
+
 	#endregion
 }


### PR DESCRIPTION
[null-keyword]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/null
[argument-null-exception]: https://learn.microsoft.com/en-us/dotnet/api/system.argumentnullexception?view=net-8.0

<!-- ## Ticket(s) <!-- Optional -->

## Topic <!-- Required -->

- [x] Feature <!-- Indicates a relationship with a feature or enhancement -->
- [ ] Test <!-- Indicates a relationship with a testing process -->
- [ ] Build <!-- Indicates a relationship with a build process -->
- [ ] Dependency <!-- Indicates a relationship with a development or production dependency -->
- [ ] Bug <!-- Indicates a relationship with a bug or unintended behavior -->
- [ ] Refactor <!-- Indicates a relationship with a refactoring process -->
- [ ] Style <!-- Indicates a relationship with a code style process -->
- [ ] Chore <!-- Indicates a relationship with a maintenance process (does not affect production code) -->
- [ ] Documentation <!-- Indicates a relationship with a documentation process -->
- [ ] Workflow <!-- Indicates a relationship with a CI/CD process -->

## Description <!-- Required -->

Added fourth overload of the [implicit operator](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/user-defined-conversion-operators). The details that make up this action are:

- Type: [Result<TSuccess, TFailure>](source/Monads/Result.cs).
- Signature:

  ```cs
  public static implicit operator Result<TSuccess, TFailure>(Func<TFailure> createFailure)
  ```

- Summary: Creates a new failed result.
- Parameters:
  - `createFailure`: Creates the possible failure (if `createFailure` is [null][null-keyword] or its value is [null][null-keyword], [ArgumentNullException][argument-null-exception] will be thrown).
- Exceptions:
  - [ArgumentNullException][argument-null-exception].

<!-- ## Evidence <!-- Optional -->
