### PR TITLE
feature: add `Ensure` method

### DIFF
--- a/source/Monads/Extensions/ResultExtension.cs
+++ b/source/Monads/Extensions/ResultExtension.cs
@@ -1,0 +1,35 @@
+namespace Daht.Sagitta.Core.Monads.Extensions;
+
+/// <summary>Type that extends the behavior of <see cref="Result{TFailure, TSuccess}"/>.</summary>
+public static class ResultExtension
+{
+	/// <summary>Creates a new failed result if the value of <paramref name="predicate"/> is <see langword="true"/>; otherwise, returns the previous result.</summary>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
+	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <param name="result">The result to extend.</param>
+	/// <param name="predicate">
+	///		<para>Creates a set of criteria.</para>
+	///		<para>If <paramref name="predicate"/> is <see langword="null"/>, <seealso cref="ArgumentNullException"/> will be thrown.</para>
+	/// </param>
+	/// <param name="failure">
+	///     <para>The possible failure.</para>
+	///     <para>If <paramref name="failure"/> is <see langword="null"/>, <seealso cref="ArgumentNullException"/> will be thrown.</para>
+	/// </param>
+	/// <returns>A new failed result if the value of <paramref name="predicate"/> is <see langword="true"/>; otherwise, the previous result.</returns>
+	/// <exception cref="ArgumentNullException"/>
+	public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(this Result<TSuccess, TFailure> result, Func<TSuccess, bool> predicate, TFailure failure)
+		where TSuccess : notnull
+		where TFailure : notnull
+	{
+		if (result.IsFailedOrDefault)
+			return result;
+		ArgumentNullException.ThrowIfNull(predicate);
+		if (predicate(result.Success))
+		{
+			return failure is null
+				? throw new ArgumentNullException(nameof(failure))
+				: Result.Fail<TSuccess, TFailure>(failure);
+		}
+		return result;
+	}
+}

--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -262,7 +262,6 @@ public readonly record struct Result<TSuccess, TFailure>
 	/// </param>
 	/// <returns>A new failed result.</returns>
 	/// <exception cref="ArgumentNullException"/>
-	/// <exception cref="ArgumentNullException"/>
 	public static implicit operator Result<TSuccess, TFailure>(Func<TFailure> createFailure)
 		=> Result.Fail<TSuccess, TFailure>(createFailure);
 }

--- a/test/unit/GlobalImport.cs
+++ b/test/unit/GlobalImport.cs
@@ -1,6 +1,8 @@
 global using Daht.Sagitta.Core.Monads;
+global using Daht.Sagitta.Core.Monads.Extensions;
 global using Daht.Sagitta.Core.UnitTest.Monads.Asserters;
 global using Daht.Sagitta.Core.UnitTest.Monads.Fixtures;
+global using Daht.Sagitta.Core.UnitTest.Monads.Mothers;
 global using Daht.Sagitta.Core.UnitTest.Shared.Exceptions;
 global using Daht.Sagitta.Core.UnitTest.Shared.Exceptions.Asserters;
 global using Daht.Sagitta.Core.UnitTest.Shared.Fakers;

--- a/test/unit/Monads/Asserters/ResultAsserter.cs
+++ b/test/unit/Monads/Asserters/ResultAsserter.cs
@@ -2,6 +2,18 @@ namespace Daht.Sagitta.Core.UnitTest.Monads.Asserters;
 
 internal static class ResultAsserter
 {
+	internal static void IsDefault<TSuccess, TFailure>(Result<TSuccess, TFailure> actualResult)
+		where TSuccess : notnull
+		where TFailure : notnull
+	{
+		Assert.True(actualResult.IsSuccessfulOrDefault);
+		Assert.True(actualResult.IsFailedOrDefault);
+		Assert.True(actualResult.IsDefault);
+		Assert.False(actualResult.IsSuccessful);
+		Assert.Equal(default, actualResult.Success);
+		Assert.False(actualResult.IsFailed);
+		Assert.Equal(default, actualResult.Failure);
+	}
 	internal static void AreSuccessful<TSuccess, TFailure>(TSuccess expectedSuccess, Result<TSuccess, TFailure> actualResult)
 		where TSuccess : notnull
 		where TFailure : notnull

--- a/test/unit/Monads/Extensions/ResultExtensionTest.cs
+++ b/test/unit/Monads/Extensions/ResultExtensionTest.cs
@@ -1,0 +1,120 @@
+namespace Daht.Sagitta.Core.UnitTest.Monads.Extensions;
+
+public sealed class ResultExtensionTest
+{
+	private const string root = nameof(ResultExtension);
+
+	private const string ensure = nameof(ResultExtension.Ensure);
+
+	#region Ensure
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_DefaultResultPlusFalsePredicatePlusFailure_DefaultResult()
+	{
+		//Arrange
+		Func<Constellation, bool> predicate = static _ => false;
+		const string failure = ResultFixture.Failure;
+
+		//Act
+		Result<Constellation, string> actualResult = ResultMother
+			.Default
+			.Ensure(predicate, failure);
+
+		//Assert
+		ResultAsserter.IsDefault(actualResult);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_FailedResultPlusFalsePredicatePlusFailure_FailedResult()
+	{
+		//Arrange
+		const string expectedFailure = ResultFixture.Failure;
+		Func<Constellation, bool> predicate = static _ => false;
+		string failure = ResultFixture.RandomFailure;
+
+		//Act
+		Result<Constellation, string> actualResult = ResultMother
+			.Fail(expectedFailure)
+			.Ensure(predicate, failure);
+
+		//Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_SuccessfulResultPlusNullPredicatePlusFailure_ArgumentNullException()
+	{
+		//Arrange
+		const Func<Constellation, bool> predicate = null!;
+		const string failure = ResultFixture.Failure;
+
+		//Act
+		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(
+			static () => _ = ResultMother
+				.Succeed()
+				.Ensure(predicate, failure)
+		);
+
+		//Assert
+		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(predicate), actualException);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_SuccessfulResultPlusTruePredicatePlusNullFailure_ArgumentNullException()
+	{
+		//Arrange
+		Func<Constellation, bool> predicate = static _ => true;
+		const string failure = null!;
+
+		//Act
+		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(
+			() => _ = ResultMother
+				.Succeed()
+				.Ensure(predicate, failure)
+		);
+
+		//Assert
+		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(failure), actualException);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_SuccessfulResultPlusTruePredicatePlusFailure_FailedResult()
+	{
+		//Arrange
+		Func<Constellation, bool> predicate = static _ => true;
+		const string expectedFailure = ResultFixture.Failure;
+
+		//Act
+		Result<Constellation, string> actualResult = ResultMother
+			.Succeed()
+			.Ensure(predicate, expectedFailure);
+
+		//Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_SuccessfulResultPlusFalsePredicatePlusFailure_SuccessfulResult()
+	{
+		//Arrange
+		Constellation expectedSuccess = ResultFixture.Success;
+		Func<Constellation, bool> predicate = static _ => false;
+		const string failure = ResultFixture.Failure;
+
+		//Act
+		Result<Constellation, string> actualResult = ResultMother
+			.Succeed(expectedSuccess)
+			.Ensure(predicate, failure);
+
+		//Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
+
+	#endregion
+}

--- a/test/unit/Monads/Fixtures/ResultFixture.cs
+++ b/test/unit/Monads/Fixtures/ResultFixture.cs
@@ -10,5 +10,7 @@ internal static class ResultFixture
 			Symbolism = "The arrow"
 		};
 
+	internal static string RandomFailure => $"{Failure} | {Guid.NewGuid()}";
+
 	internal const string Failure = nameof(Failure);
 }

--- a/test/unit/Monads/Mothers/ResultMother.cs
+++ b/test/unit/Monads/Mothers/ResultMother.cs
@@ -1,0 +1,15 @@
+namespace Daht.Sagitta.Core.UnitTest.Monads.Mothers;
+
+internal static class ResultMother
+{
+	internal static Result<Constellation, string> Default => default;
+
+	internal static Result<Constellation, string> Succeed()
+		=> Result.Succeed<Constellation, string>(ResultFixture.Success);
+
+	internal static Result<Constellation, string> Succeed(Constellation success)
+		=> Result.Succeed<Constellation, string>(success);
+
+	internal static Result<Constellation, string> Fail(string failure)
+		=> Result.Fail<Constellation, string>(failure);
+}


### PR DESCRIPTION
[null-keyword]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/null
[argument-null-exception]: https://learn.microsoft.com/en-us/dotnet/api/system.argumentnullexception?view=net-8.0

<!-- ## Ticket(s) <!-- Optional -->

## Topic <!-- Required -->

- [x] Feature <!-- Indicates a relationship with a feature or enhancement -->
- [ ] Test <!-- Indicates a relationship with a testing process -->
- [ ] Build <!-- Indicates a relationship with a build process -->
- [ ] Dependency <!-- Indicates a relationship with a development or production dependency -->
- [ ] Bug <!-- Indicates a relationship with a bug or unintended behavior -->
- [ ] Refactor <!-- Indicates a relationship with a refactoring process -->
- [ ] Style <!-- Indicates a relationship with a code style process -->
- [ ] Chore <!-- Indicates a relationship with a maintenance process (does not affect production code) -->
- [ ] Documentation <!-- Indicates a relationship with a documentation process -->
- [ ] Workflow <!-- Indicates a relationship with a CI/CD process -->

## Description <!-- Required -->

Added `Ensure` method. The details that make up this action are:

- Type: [ResultExtension](source/Monads/Extensions/ResultExtension.cs).
- Signature:

  ```cs
  public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(this Result<TSuccess, TFailure> result, Func<TSuccess, bool> predicate, TFailure failure)
    where TSuccess : notnull
    where TFailure : notnull
  ```

- Summary: Creates a new failed result if the value of `predicate` is [true](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/true-false-operators); otherwise, returns the previous result.
- Generics:
  - `TSuccess`: Type of expected success.
  - `TFailure`: Type of possible failure.
- Parameters:
  - `result`: The result to extend.
  - `predicate`: Creates a set of criteria (if `predicate` is [null][null-keyword], [ArgumentNullException][argument-null-exception] will be thrown).
  - `failure`: The possible failure (if `failure` is [null][null-keyword], [ArgumentNullException][argument-null-exception] will be thrown).
- Exceptions:
  - [ArgumentNullException][argument-null-exception].

<!-- ## Evidence <!-- Optional -->
