### PR TITLE
feature: remove all overloads that receive delegates implicitly

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -235,16 +235,6 @@ public readonly record struct Result<TSuccess, TFailure>
 	public static implicit operator Result<TSuccess, TFailure>(TSuccess success)
 		=> Result.Succeed<TSuccess, TFailure>(success);
 
-	/// <summary>Creates a new successful result.</summary>
-	/// <param name="createSuccess">
-	///     <para>Creates the expected success.</para>
-	///     <para>If <paramref name="createSuccess"/> is <see langword="null"/> or its value is <see langword="null"/>, <seealso cref="ArgumentNullException"/> will be thrown.</para>
-	/// </param>
-	/// <returns>A new successful result.</returns>
-	/// <exception cref="ArgumentNullException"/>
-	public static implicit operator Result<TSuccess, TFailure>(Func<TSuccess> createSuccess)
-		=> Result.Succeed<TSuccess, TFailure>(createSuccess);
-
 	/// <summary>Creates a new failed result.</summary>
 	/// <param name="failure">
 	///     <para>The possible failure.</para>
@@ -254,14 +244,4 @@ public readonly record struct Result<TSuccess, TFailure>
 	/// <exception cref="ArgumentNullException"/>
 	public static implicit operator Result<TSuccess, TFailure>(TFailure failure)
 		=> Result.Fail<TSuccess, TFailure>(failure);
-
-	/// <summary>Creates a new failed result.</summary>
-	/// <param name="createFailure">
-	///     <para>Creates the possible failure.</para>
-	///     <para>If <paramref name="createFailure"/> is <see langword="null"/> or its value is <see langword="null"/>, <seealso cref="ArgumentNullException"/> will be thrown.</para>
-	/// </param>
-	/// <returns>A new failed result.</returns>
-	/// <exception cref="ArgumentNullException"/>
-	public static implicit operator Result<TSuccess, TFailure>(Func<TFailure> createFailure)
-		=> Result.Fail<TSuccess, TFailure>(createFailure);
 }

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -620,67 +620,6 @@ public sealed class ResultTest
 
 	[Fact]
 	[Trait(root, implicitOperator)]
-	public void ImplicitOperator_NullCreateSuccess_ArgumentNullException()
-	{
-		//Arrange
-		const Func<Constellation> createSuccess = null!;
-
-		//Act
-		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(
-			static () =>
-			{
-#pragma warning disable S1481
-				Result<Constellation, string> _ = createSuccess;
-#pragma warning restore S1481
-			}
-		);
-
-		//Assert
-		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(createSuccess), actualException);
-	}
-
-	[Fact]
-	[Trait(root, implicitOperator)]
-	public void ImplicitOperator_CreateSuccessWithNullValue_ArgumentNullException()
-	{
-		//Arrange
-		Func<Constellation> createSuccess = static () => null!;
-
-		//Act
-		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(
-			() =>
-			{
-#pragma warning disable S1481
-				Result<Constellation, string> _ = createSuccess;
-#pragma warning restore S1481
-			}
-		);
-
-		//Assert
-		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(createSuccess), actualException);
-	}
-
-	[Fact]
-	[Trait(root, implicitOperator)]
-	public void ImplicitOperator_CreateSuccess_SuccessfulResult()
-	{
-		//Arrange
-		Constellation expectedSuccess = ResultFixture.Success;
-		Func<Constellation> createSuccess = () => expectedSuccess;
-
-		//Act
-		Result<Constellation, string> actualResult = createSuccess;
-
-		//Assert
-		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
-	}
-
-	#endregion
-
-	#region Overload No. 03
-
-	[Fact]
-	[Trait(root, implicitOperator)]
 	public void ImplicitOperator_NullFailure_ArgumentNullException()
 	{
 		//Arrange
@@ -709,67 +648,6 @@ public sealed class ResultTest
 
 		//Act
 		Result<Constellation, string> actualResult = expectedFailure;
-
-		//Assert
-		ResultAsserter.AreFailed(expectedFailure, actualResult);
-	}
-
-	#endregion
-
-	#region Overload No. 04
-
-	[Fact]
-	[Trait(root, implicitOperator)]
-	public void ImplicitOperator_NullCreateFailure_ArgumentNullException()
-	{
-		//Arrange
-		const Func<string> createFailure = null!;
-
-		//Act
-		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(
-			static () =>
-			{
-#pragma warning disable S1481
-				Result<Constellation, string> _ = createFailure;
-#pragma warning restore S1481
-			}
-		);
-
-		//Assert
-		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(createFailure), actualException);
-	}
-
-	[Fact]
-	[Trait(root, implicitOperator)]
-	public void ImplicitOperator_CreateFailureWithNullValue_ArgumentNullException()
-	{
-		//Arrange
-		Func<string> createFailure = static () => null!;
-
-		//Act
-		ArgumentNullException? actualException = ExceptionHandler.Catch<ArgumentNullException>(
-			() =>
-			{
-#pragma warning disable S1481
-				Result<Constellation, string> _ = createFailure;
-#pragma warning restore S1481
-			}
-		);
-
-		//Assert
-		ArgumentNullExceptionAsserter.AreEqualParameterNames(nameof(createFailure), actualException);
-	}
-
-	[Fact]
-	[Trait(root, implicitOperator)]
-	public void ImplicitOperator_CreateFailure_FailedResult()
-	{
-		//Arrange
-		const string expectedFailure = ResultFixture.Failure;
-		Func<string> createFailure = static () => expectedFailure;
-
-		//Act
-		Result<Constellation, string> actualResult = createFailure;
 
 		//Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);


### PR DESCRIPTION

<!-- ## Ticket(s) <!-- Optional -->

## Description <!-- Required -->

The purpose of this decision is to eliminate the difficulty and possible confusion in using implicit operators with complex types. The alternatives are:

- Type: [Result](source/Monads/Result.cs).
  - Signatures:

      ```cs
      public static Result<TSuccess, TFailure> Succeed<TSuccess, TFailure>(Func<TSuccess> createSuccess)
        where TSuccess : notnull
        where TFailure : notnull
      ```

      ```cs
      public static Result<TSuccess, TFailure> Fail<TSuccess, TFailure>(Func<TFailure> createFailure)
        where TSuccess : notnull
        where TFailure : notnull
      ```

<!-- ## Evidence <!-- Optional -->
