### PR TITLE
feature: replace `Result<TSuccess, TFailure>` type from `struct` to `class`

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -3,32 +3,35 @@ namespace Daht.Sagitta.Core.Monads;
 /// <summary>Type that encapsulates both the expected success and the possible failure of a given action.</summary>
 /// <typeparam name="TSuccess">Type of expected success.</typeparam>
 ///	<typeparam name="TFailure">Type of possible failure.</typeparam>
-public readonly record struct Result<TSuccess, TFailure>
+public sealed class Result<TSuccess, TFailure>
 {
-	/// <summary>Indicates whether the status is successful or <see langword="default"/>.</summary>
-	public bool IsSuccessfulOrDefault => IsSuccessful || IsDefault;
-
-	/// <summary>Indicates whether the status is failed or <see langword="default"/>.</summary>
-	public bool IsFailedOrDefault => IsFailed || IsDefault;
-
-	/// <summary>Indicates whether the status is <see langword="default"/>.</summary>
-	public bool IsDefault => this is
-	{
-		IsSuccessful: false,
-		IsFailed: false
-	};
-
 	/// <summary>Indicates whether the status is successful.</summary>
-	public bool IsSuccessful { get; internal init; }
+	public bool IsSuccessful { get; }
 
 	/// <summary>The expected success.</summary>
-	public TSuccess Success { get; internal init; }
+	public TSuccess Success { get; } = default!;
 
 	/// <summary>Indicates whether the status is failed.</summary>
-	public bool IsFailed { get; internal init; }
+	public bool IsFailed { get; }
 
 	/// <summary>The possible failure.</summary>
-	public TFailure Failure { get; internal init; }
+	public TFailure Failure { get; } = default!;
+
+	/// <summary>Creates a new successful result.</summary>
+	/// <param name="success">The expected success.</param>
+	public Result(TSuccess success)
+	{
+		IsSuccessful = true;
+		Success = success;
+	}
+
+	/// <summary>Creates a new failed result.</summary>
+	/// <param name="failure">The possible failure.</param>
+	public Result(TFailure failure)
+	{
+		IsFailed = true;
+		Failure = failure;
+	}
 
 	/// <summary>Creates a new successful result.</summary>
 	/// <param name="success">The expected success.</param>
@@ -48,11 +51,11 @@ public readonly record struct Result<TSuccess, TFailure>
 	/// <returns>A new failed result if the value of <paramref name="predicate"/> is <see langword="true"/>; otherwise, the previous result.</returns>
 	public Result<TSuccess, TFailure> Ensure([NotNull] Func<TSuccess, bool> predicate, TFailure failure)
 	{
-		if (IsFailedOrDefault)
+		if (IsFailed)
 		{
 			return this;
 		}
-		if (predicate(Success))
+		else if (predicate(Success))
 		{
 			return ResultFactory.Fail<TSuccess, TFailure>(failure);
 		}

--- a/source/Monads/ResultFactory.cs
+++ b/source/Monads/ResultFactory.cs
@@ -29,11 +29,7 @@ public static class ResultFactory
 	/// <param name="success">The expected success.</param>
 	/// <returns>A new successful result.</returns>
 	public static Result<TSuccess, TFailure> Succeed<TSuccess, TFailure>(TSuccess success)
-		=> new()
-		{
-			IsSuccessful = true,
-			Success = success
-		};
+		=> new(success);
 
 	/// <summary>Creates a new successful result.</summary>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
@@ -41,7 +37,7 @@ public static class ResultFactory
 	/// <param name="createSuccess">Creates the expected success.</param>
 	/// <returns>A new successful result.</returns>
 	public static Result<TSuccess, TFailure> Succeed<TSuccess, TFailure>([NotNull] Func<TSuccess> createSuccess)
-		=> Succeed<TSuccess, TFailure>(createSuccess());
+		=> new(createSuccess());
 
 	/// <summary>Creates a new failed result.</summary>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
@@ -49,11 +45,7 @@ public static class ResultFactory
 	/// <param name="failure">The possible failure.</param>
 	/// <returns>A new failed result.</returns>
 	public static Result<TSuccess, TFailure> Fail<TSuccess, TFailure>(TFailure failure)
-		=> new()
-		{
-			IsFailed = true,
-			Failure = failure
-		};
+		=> new(failure);
 
 	/// <summary>Creates a new failed result.</summary>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
@@ -61,5 +53,5 @@ public static class ResultFactory
 	/// <param name="createFailure">Creates the possible failure.</param>
 	/// <returns>A new failed result.</returns>
 	public static Result<TSuccess, TFailure> Fail<TSuccess, TFailure>([NotNull] Func<TFailure> createFailure)
-		=> Fail<TSuccess, TFailure>(createFailure());
+		=> new(createFailure());
 }

--- a/source/Sagitta.Core.csproj
+++ b/source/Sagitta.Core.csproj
@@ -10,7 +10,7 @@
 		<Description>Functional paradigm abstractions | Core</Description>
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
-		<PackageTags>$(Company); Sagitta; Functional-paradigm; Result</PackageTags>
+		<PackageTags>$(Company); Sagitta; Functional; Paradigm; Result</PackageTags>
 		<NeutralLanguage>en-US</NeutralLanguage>
 		<RepositoryType>git</RepositoryType>
 		<RepositoryUrl>https://github.com/daht-x/sagitta-core</RepositoryUrl>

--- a/test/unit/Monads/Asserters/ResultAsserter.cs
+++ b/test/unit/Monads/Asserters/ResultAsserter.cs
@@ -2,21 +2,8 @@ namespace Daht.Sagitta.Core.UnitTest.Monads.Asserters;
 
 internal static class ResultAsserter
 {
-	internal static void IsDefault<TSuccess, TFailure>(Result<TSuccess, TFailure> actualResult)
-	{
-		Assert.True(actualResult.IsSuccessfulOrDefault);
-		Assert.True(actualResult.IsFailedOrDefault);
-		Assert.True(actualResult.IsDefault);
-		Assert.False(actualResult.IsSuccessful);
-		Assert.Equal(default, actualResult.Success);
-		Assert.False(actualResult.IsFailed);
-		Assert.Equal(default, actualResult.Failure);
-	}
 	internal static void AreSuccessful<TSuccess, TFailure>(TSuccess expectedSuccess, Result<TSuccess, TFailure> actualResult)
 	{
-		Assert.True(actualResult.IsSuccessfulOrDefault);
-		Assert.False(actualResult.IsFailedOrDefault);
-		Assert.False(actualResult.IsDefault);
 		Assert.True(actualResult.IsSuccessful);
 		Assert.Equal(expectedSuccess, actualResult.Success);
 		Assert.False(actualResult.IsFailed);
@@ -25,9 +12,6 @@ internal static class ResultAsserter
 
 	internal static void AreFailed<TSuccess, TFailure>(TFailure expectedFailure, Result<TSuccess, TFailure> actualResult)
 	{
-		Assert.False(actualResult.IsSuccessfulOrDefault);
-		Assert.True(actualResult.IsFailedOrDefault);
-		Assert.False(actualResult.IsDefault);
 		Assert.False(actualResult.IsSuccessful);
 		Assert.Equal(default, actualResult.Success);
 		Assert.True(actualResult.IsFailed);

--- a/test/unit/Monads/Mothers/ResultMother.cs
+++ b/test/unit/Monads/Mothers/ResultMother.cs
@@ -2,8 +2,6 @@ namespace Daht.Sagitta.Core.UnitTest.Monads.Mothers;
 
 internal static class ResultMother
 {
-	internal static Result<Constellation, string> Default => default;
-
 	internal static Result<Constellation, string> Succeed()
 		=> ResultFactory.Succeed<Constellation, string>(ResultFixture.Success);
 

--- a/test/unit/Monads/ResultFactoryTest.cs
+++ b/test/unit/Monads/ResultFactoryTest.cs
@@ -48,7 +48,7 @@ public sealed class ResultFactoryTest
 
 	#region Succeed
 
-	#region Overload No. 01
+	#region Overload
 
 	[Fact]
 	[Trait(root, succeed)]
@@ -66,7 +66,7 @@ public sealed class ResultFactoryTest
 
 	#endregion
 
-	#region Overload No. 02
+	#region Overload
 
 	[Fact]
 	[Trait(root, succeed)]
@@ -89,7 +89,7 @@ public sealed class ResultFactoryTest
 
 	#region Fail
 
-	#region Overload No. 01
+	#region Overload
 
 	[Fact]
 	[Trait(root, fail)]
@@ -107,7 +107,7 @@ public sealed class ResultFactoryTest
 
 	#endregion
 
-	#region Overload No. 02
+	#region Overload
 
 	[Fact]
 	[Trait(root, fail)]

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -4,13 +4,55 @@ public sealed class ResultTest
 {
 	private const string root = nameof(Result<object, object>);
 
+	private const string constructor = "Constructor";
+
 	private const string implicitOperator = "Implicit Operator";
 
 	private const string ensure = nameof(Result<object, object>.Ensure);
 
+	#region Constructor
+
+	#region Overload
+
+	[Fact]
+	[Trait(root, constructor)]
+	public void Constructor_Success_SuccessfulResult()
+	{
+		//Arrange
+		Constellation expectedSuccess = ResultFixture.Success;
+
+		//Act
+		Result<Constellation, string> actualResult = new(expectedSuccess);
+
+		//Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
+
+	#endregion
+
+	#region Overload
+
+	[Fact]
+	[Trait(root, constructor)]
+	public void Constructor_Failure_FailedResult()
+	{
+		//Arrange
+		const string expectedFailure = ResultFixture.Failure;
+
+		//Act
+		Result<Constellation, string> actualResult = new(expectedFailure);
+
+		//Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	#endregion
+
+	#endregion
+
 	#region Implicit Operator
 
-	#region Overload No. 01
+	#region Overload
 
 	[Fact]
 	[Trait(root, implicitOperator)]
@@ -28,7 +70,7 @@ public sealed class ResultTest
 
 	#endregion
 
-	#region Overload No. 02
+	#region Overload
 
 	[Fact]
 	[Trait(root, implicitOperator)]
@@ -49,23 +91,6 @@ public sealed class ResultTest
 	#endregion
 
 	#region Ensure
-
-	[Fact]
-	[Trait(root, ensure)]
-	public void Ensure_DefaultResultPlusFalsePredicatePlusFailure_DefaultResult()
-	{
-		//Arrange
-		Func<Constellation, bool> predicate = static _ => false;
-		const string failure = ResultFixture.Failure;
-
-		//Act
-		Result<Constellation, string> actualResult = ResultMother
-			.Default
-			.Ensure(predicate, failure);
-
-		//Assert
-		ResultAsserter.IsDefault(actualResult);
-	}
 
 	[Fact]
 	[Trait(root, ensure)]


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Description <!-- Required -->

The purpose of this change is to use the most appropriate type, since both `TSuccess` and `TFailure` are typically used as reference types instead of value types.
Using a value type with multiple reference types can be counterproductive, as it violates the philosophy behind the `structs`, which should generate instances smaller than [16 bytes](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/choosing-between-class-and-struct?redirectedfrom=MSDN) and their members should be value types.

[default-keyword]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/default1

The side effects of this change are:

- Removed:
  - Type: [Result<TSuccess, TFailure>](source/Monads/Result.cs).
    - Signature:

        ```cs
        public bool IsSuccessfulOrDefault
        ```

      - Member: Property.
      - Description: Indicates whether the status is successful or [default][default-keyword].
    - Signature:

        ```cs
        public bool IsFailedOrDefault
        ```

      - Member: Property.
      - Description: Indicates whether the status is failed or [default][default-keyword].
    - Signature:

        ```cs
        public bool IsDefault
        ```

      - Member: Property.
      - Description: Indicates whether the status is [default][default-keyword].

- Added:
  - Type: [Result<TSuccess, TFailure>](source/Monads/Result.cs).
    - Signature:

        ```cs
        public Result(TSuccess success)
        ```

      - Member: Constructor.
      - Description: Creates a new successful result.
      - Parameters:
        - `success`: The expected success.
    - Signature:

        ```cs
        public Result(TFailure failure)
        ```

      - Member: Constructor.
      - Description: Creates a new failed result.
      - Parameters:
        - `failure`: The possible failure.

<!-- ## Evidence <!-- Optional -->
