### PR TITLE
refactor: replace all `NotNull` attributes with the `pragma` directive

### DIFF
--- a/source/Global.cs
+++ b/source/Global.cs
@@ -1,1 +1,0 @@
-global using System.Diagnostics.CodeAnalysis;

--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -1,22 +1,11 @@
 namespace Daht.Sagitta.Core.Monads;
 
+#pragma warning disable CA1062
 /// <summary>Type that encapsulates both the expected success and the possible failure of a given action.</summary>
 /// <typeparam name="TSuccess">Type of expected success.</typeparam>
-///	<typeparam name="TFailure">Type of possible failure.</typeparam>
+/// <typeparam name="TFailure">Type of possible failure.</typeparam>
 public sealed class Result<TSuccess, TFailure>
 {
-	/// <summary>Indicates whether the status is successful.</summary>
-	public bool IsSuccessful { get; }
-
-	/// <summary>The expected success.</summary>
-	public TSuccess Success { get; } = default!;
-
-	/// <summary>Indicates whether the status is failed.</summary>
-	public bool IsFailed { get; }
-
-	/// <summary>The possible failure.</summary>
-	public TFailure Failure { get; } = default!;
-
 	/// <summary>Creates a new successful result.</summary>
 	/// <param name="success">The expected success.</param>
 	public Result(TSuccess success)
@@ -33,32 +22,43 @@ public sealed class Result<TSuccess, TFailure>
 		Failure = failure;
 	}
 
+	/// <summary>Indicates whether the status is successful.</summary>
+	public bool IsSuccessful { get; }
+
+	/// <summary>The expected success.</summary>
+	public TSuccess Success { get; } = default!;
+
+	/// <summary>Indicates whether the status is failed.</summary>
+	public bool IsFailed { get; }
+
+	/// <summary>The possible failure.</summary>
+	public TFailure Failure { get; } = default!;
+
 	/// <summary>Creates a new successful result.</summary>
 	/// <param name="success">The expected success.</param>
 	/// <returns>A new successful result.</returns>
 	public static implicit operator Result<TSuccess, TFailure>(TSuccess success)
-		=> ResultFactory.Succeed<TSuccess, TFailure>(success);
+		=> new(success);
 
 	/// <summary>Creates a new failed result.</summary>
 	/// <param name="failure">The possible failure.</param>
 	/// <returns>A new failed result.</returns>
 	public static implicit operator Result<TSuccess, TFailure>(TFailure failure)
-		=> ResultFactory.Fail<TSuccess, TFailure>(failure);
+		=> new(failure);
 
-	/// <summary>Creates a new failed result if the value of <paramref name="predicate"/> is <see langword="true"/>; otherwise, returns the previous result.</summary>
+	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
 	/// <param name="predicate">Creates a set of criteria.</param>
 	/// <param name="failure">The possible failure.</param>
-	/// <returns>A new failed result if the value of <paramref name="predicate"/> is <see langword="true"/>; otherwise, the previous result.</returns>
-	public Result<TSuccess, TFailure> Ensure([NotNull] Func<TSuccess, bool> predicate, TFailure failure)
+	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
+	public Result<TSuccess, TFailure> Ensure(Func<TSuccess, bool> predicate, TFailure failure)
 	{
 		if (IsFailed)
 		{
 			return this;
 		}
-		else if (predicate(Success))
-		{
-			return ResultFactory.Fail<TSuccess, TFailure>(failure);
-		}
-		return this;
+		return predicate(Success)
+			? new(failure)
+			: this;
 	}
 }
+#pragma warning restore CA1062

--- a/source/Monads/ResultFactory.cs
+++ b/source/Monads/ResultFactory.cs
@@ -1,16 +1,17 @@
 namespace Daht.Sagitta.Core.Monads;
 
-/// <summary>Type that exposes a set of ways to initialize <see cref="Result{TFailure, TSuccess}"/>.</summary>
+#pragma warning disable CA1062
+/// <summary>Type that exposes a set of ways to initialize <see cref="Result{TFailure, TSuccess}" />.</summary>
 public static class ResultFactory
 {
-	/// <summary>Creates a new failed result if the value of <paramref name="createSuccess"/> throws <typeparamref name="TException"/>; otherwise, creates a new successful result.</summary>
+	/// <summary>Creates a new failed result if the value of <paramref name="createSuccess" /> throws <typeparamref name="TException" />; otherwise, creates a new successful result.</summary>
 	/// <typeparam name="TException">Type of possible exception.</typeparam>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
 	/// <param name="createSuccess">Creates the expected success.</param>
-	/// <param name="createFailure">Creates the possible failure in combination with <typeparamref name="TException"/>.</param>
-	/// <returns>A new failed result if the value of <paramref name="createSuccess"/> throws <typeparamref name="TException"/>; otherwise, a new successful result.</returns>
-	public static Result<TSuccess, TFailure> Catch<TException, TSuccess, TFailure>([NotNull] Func<TSuccess> createSuccess, [NotNull] Func<TException, TFailure> createFailure)
+	/// <param name="createFailure">Creates the possible failure in combination with <typeparamref name="TException" />.</param>
+	/// <returns>A new failed result if the value of <paramref name="createSuccess" /> throws <typeparamref name="TException" />; otherwise, a new successful result.</returns>
+	public static Result<TSuccess, TFailure> Catch<TException, TSuccess, TFailure>(Func<TSuccess> createSuccess, Func<TException, TFailure> createFailure)
 		where TException : Exception
 	{
 		try
@@ -36,7 +37,7 @@ public static class ResultFactory
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
 	/// <param name="createSuccess">Creates the expected success.</param>
 	/// <returns>A new successful result.</returns>
-	public static Result<TSuccess, TFailure> Succeed<TSuccess, TFailure>([NotNull] Func<TSuccess> createSuccess)
+	public static Result<TSuccess, TFailure> Succeed<TSuccess, TFailure>(Func<TSuccess> createSuccess)
 		=> new(createSuccess());
 
 	/// <summary>Creates a new failed result.</summary>
@@ -52,6 +53,7 @@ public static class ResultFactory
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
 	/// <param name="createFailure">Creates the possible failure.</param>
 	/// <returns>A new failed result.</returns>
-	public static Result<TSuccess, TFailure> Fail<TSuccess, TFailure>([NotNull] Func<TFailure> createFailure)
+	public static Result<TSuccess, TFailure> Fail<TSuccess, TFailure>(Func<TFailure> createFailure)
 		=> new(createFailure());
 }
+#pragma warning restore CA1062

--- a/test/unit/Monads/Fixtures/ResultFixture.cs
+++ b/test/unit/Monads/Fixtures/ResultFixture.cs
@@ -2,6 +2,8 @@ namespace Daht.Sagitta.Core.UnitTest.Monads.Fixtures;
 
 internal static class ResultFixture
 {
+	internal const string Failure = nameof(ResultFixture.Failure);
+
 	internal static Constellation Success
 		=> new()
 		{
@@ -10,7 +12,6 @@ internal static class ResultFixture
 			Symbolism = "The arrow"
 		};
 
-	internal static string RandomFailure => $"{Failure} | {Guid.NewGuid()}";
-
-	internal const string Failure = nameof(Failure);
+	internal static string RandomFailure
+		=> $"{ResultFixture.Failure} | {Guid.NewGuid()}";
 }

--- a/test/unit/Monads/ResultFactoryTest.cs
+++ b/test/unit/Monads/ResultFactoryTest.cs
@@ -13,32 +13,36 @@ public sealed class ResultFactoryTest
 	#region Catch
 
 	[Fact]
-	[Trait(root, @catch)]
+	[Trait(ResultFactoryTest.root, ResultFactoryTest.@catch)]
 	public void Catch_CreateSuccessPlusCreateFailure_SuccessfulResult()
 	{
 		//Arrange
 		Constellation expectedSuccess = ResultFixture.Success;
-		Func<Constellation> createSuccess = () => expectedSuccess;
-		Func<InvalidOperationException, string> createFailure = static exception => exception.Message;
+		Constellation CreateSuccess()
+			=> expectedSuccess;
+		static string CreateFailure(InvalidOperationException exception)
+			=> exception.Message;
 
 		//Act
-		Result<Constellation, string> actualResult = ResultFactory.Catch(createSuccess, createFailure);
+		Result<Constellation, string> actualResult = ResultFactory.Catch<InvalidOperationException, Constellation, string>(CreateSuccess, CreateFailure);
 
 		//Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
 	}
 
 	[Fact]
-	[Trait(root, @catch)]
+	[Trait(ResultFactoryTest.root, ResultFactoryTest.@catch)]
 	public void Catch_ExceptionPlusCreateFailure_FailedResult()
 	{
 		//Arrange
-		Func<Constellation> createSuccess = static () => throw new InvalidOperationException();
-		Func<InvalidOperationException, string> createFailure = static exception => exception.Message;
+		static Constellation CreateSuccess()
+			=> throw new InvalidOperationException();
+		static string CreateFailure(InvalidOperationException exception)
+			=> exception.Message;
 		const string expectedFailure = "Operation is not valid due to the current state of the object.";
 
 		//Act
-		Result<Constellation, string> actualResult = ResultFactory.Catch(createSuccess, createFailure);
+		Result<Constellation, string> actualResult = ResultFactory.Catch<InvalidOperationException, Constellation, string>(CreateSuccess, CreateFailure);
 
 		//Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
@@ -51,7 +55,7 @@ public sealed class ResultFactoryTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, succeed)]
+	[Trait(ResultFactoryTest.root, ResultFactoryTest.succeed)]
 	public void Succeed_Success_SuccessfulResult()
 	{
 		//Arrange
@@ -69,15 +73,16 @@ public sealed class ResultFactoryTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, succeed)]
+	[Trait(ResultFactoryTest.root, ResultFactoryTest.succeed)]
 	public void Succeed_CreateSuccess_SuccessfulResult()
 	{
 		//Arrange
 		Constellation expectedSuccess = ResultFixture.Success;
-		Func<Constellation> createSuccess = () => expectedSuccess;
+		Constellation CreateSuccess()
+			=> expectedSuccess;
 
 		//Act
-		Result<Constellation, string> actualResult = ResultFactory.Succeed<Constellation, string>(createSuccess);
+		Result<Constellation, string> actualResult = ResultFactory.Succeed<Constellation, string>(CreateSuccess);
 
 		//Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
@@ -92,7 +97,7 @@ public sealed class ResultFactoryTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, fail)]
+	[Trait(ResultFactoryTest.root, ResultFactoryTest.fail)]
 	public void Fail_Failure_FailedResult()
 	{
 		//Arrange
@@ -110,15 +115,16 @@ public sealed class ResultFactoryTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, fail)]
+	[Trait(ResultFactoryTest.root, ResultFactoryTest.fail)]
 	public void Fail_CreateFailure_FailedResult()
 	{
 		//Arrange
 		const string expectedFailure = ResultFixture.Failure;
-		Func<string> createFailure = static () => expectedFailure;
+		static string CreateFailure()
+			=> expectedFailure;
 
 		//Act
-		Result<Constellation, string> actualResult = ResultFactory.Fail<Constellation, string>(createFailure);
+		Result<Constellation, string> actualResult = ResultFactory.Fail<Constellation, string>(CreateFailure);
 
 		//Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -15,7 +15,7 @@ public sealed class ResultTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, constructor)]
+	[Trait(ResultTest.root, ResultTest.constructor)]
 	public void Constructor_Success_SuccessfulResult()
 	{
 		//Arrange
@@ -33,7 +33,7 @@ public sealed class ResultTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, constructor)]
+	[Trait(ResultTest.root, ResultTest.constructor)]
 	public void Constructor_Failure_FailedResult()
 	{
 		//Arrange
@@ -55,7 +55,7 @@ public sealed class ResultTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, implicitOperator)]
+	[Trait(ResultTest.root, ResultTest.implicitOperator)]
 	public void ImplicitOperator_Success_SuccessfulResult()
 	{
 		//Arrange
@@ -73,7 +73,7 @@ public sealed class ResultTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, implicitOperator)]
+	[Trait(ResultTest.root, ResultTest.implicitOperator)]
 	public void ImplicitOperator_Failure_FailedResult()
 	{
 		//Arrange
@@ -93,53 +93,53 @@ public sealed class ResultTest
 	#region Ensure
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(ResultTest.root, ResultTest.ensure)]
 	public void Ensure_FailedResultPlusFalsePredicatePlusFailure_FailedResult()
 	{
 		//Arrange
 		const string expectedFailure = ResultFixture.Failure;
-		Func<Constellation, bool> predicate = static _ => false;
+		static bool Predicate(Constellation _)
+			=> false;
 		string failure = ResultFixture.RandomFailure;
 
 		//Act
-		Result<Constellation, string> actualResult = ResultMother
-			.Fail(expectedFailure)
-			.Ensure(predicate, failure);
+		Result<Constellation, string> actualResult = ResultMother.Fail(expectedFailure)
+			.Ensure(Predicate, failure);
 
 		//Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(ResultTest.root, ResultTest.ensure)]
 	public void Ensure_SuccessfulResultPlusTruePredicatePlusFailure_FailedResult()
 	{
 		//Arrange
-		Func<Constellation, bool> predicate = static _ => true;
+		static bool Predicate(Constellation _)
+			=> true;
 		const string expectedFailure = ResultFixture.Failure;
 
 		//Act
-		Result<Constellation, string> actualResult = ResultMother
-			.Succeed()
-			.Ensure(predicate, expectedFailure);
+		Result<Constellation, string> actualResult = ResultMother.Succeed()
+			.Ensure(Predicate, expectedFailure);
 
 		//Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(ResultTest.root, ResultTest.ensure)]
 	public void Ensure_SuccessfulResultPlusFalsePredicatePlusFailure_SuccessfulResult()
 	{
 		//Arrange
 		Constellation expectedSuccess = ResultFixture.Success;
-		Func<Constellation, bool> predicate = static _ => false;
+		static bool Predicate(Constellation _)
+			=> false;
 		const string failure = ResultFixture.Failure;
 
 		//Act
-		Result<Constellation, string> actualResult = ResultMother
-			.Succeed(expectedSuccess)
-			.Ensure(predicate, failure);
+		Result<Constellation, string> actualResult = ResultMother.Succeed(expectedSuccess)
+			.Ensure(Predicate, failure);
 
 		//Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Description <!-- Required -->

The purpose of this change is to remove all [NotNull](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.codeanalysis.notnullattribute?view=net-8.0) attributes and use the [pragma](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1062) directive instead.

<!-- ## Evidence <!-- Optional -->
