### PR TITLE
feature: add `Ensure` method

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -311,7 +311,6 @@ resharper_show_autodetect_configure_formatting_tip = false
 resharper_sort_attributes = true
 resharper_space_around_arrow_op = true
 resharper_space_within_slice_pattern = false
-resharper_static_members_qualify_members = none, field
 resharper_static_members_qualify_with = current_type
 resharper_use_indent_from_vs = false
 resharper_wrap_after_primary_constructor_declaration_lpar = false

--- a/Sagitta.sln
+++ b/Sagitta.sln
@@ -1,8 +1,5 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.8.34330.188
-MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core", "Core", "{D4223882-8D25-49B3-9299-A680AFD6D275}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sagitta.Core", "source\Sagitta.Core.csproj", "{6072CBC8-9851-41C5-B3E1-C18E79C82622}"

--- a/source/Monads/ResultFactory.cs
+++ b/source/Monads/ResultFactory.cs
@@ -5,11 +5,11 @@ namespace Daht.Sagitta.Core.Monads;
 public static class ResultFactory
 {
 	/// <summary>Creates a new failed result if the value of <paramref name="createSuccess" /> throws <typeparamref name="TException" />; otherwise, creates a new successful result.</summary>
+	/// <param name="createSuccess">Creates the expected success.</param>
+	/// <param name="createFailure">Creates the possible failure in combination with <typeparamref name="TException" />.</param>
 	/// <typeparam name="TException">Type of possible exception.</typeparam>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
-	/// <param name="createSuccess">Creates the expected success.</param>
-	/// <param name="createFailure">Creates the possible failure in combination with <typeparamref name="TException" />.</param>
 	/// <returns>A new failed result if the value of <paramref name="createSuccess" /> throws <typeparamref name="TException" />; otherwise, a new successful result.</returns>
 	public static Result<TSuccess, TFailure> Catch<TException, TSuccess, TFailure>(Func<TSuccess> createSuccess, Func<TException, TFailure> createFailure)
 		where TException : Exception
@@ -24,34 +24,46 @@ public static class ResultFactory
 		}
 	}
 
-	/// <summary>Creates a new successful result.</summary>
+	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
+	/// <param name="success">The expected success.</param>
+	/// <param name="predicate">Creates a set of criteria.</param>
+	/// <param name="failure">The possible failure.</param>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
+	public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(TSuccess success, Func<TSuccess, bool> predicate, TFailure failure)
+		=> predicate(success)
+			? Fail<TSuccess, TFailure>(failure)
+			: Succeed<TSuccess, TFailure>(success);
+
+	/// <summary>Creates a new successful result.</summary>
 	/// <param name="success">The expected success.</param>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
+	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
 	/// <returns>A new successful result.</returns>
 	public static Result<TSuccess, TFailure> Succeed<TSuccess, TFailure>(TSuccess success)
 		=> new(success);
 
 	/// <summary>Creates a new successful result.</summary>
+	/// <param name="createSuccess">Creates the expected success.</param>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
-	/// <param name="createSuccess">Creates the expected success.</param>
 	/// <returns>A new successful result.</returns>
 	public static Result<TSuccess, TFailure> Succeed<TSuccess, TFailure>(Func<TSuccess> createSuccess)
 		=> new(createSuccess());
 
 	/// <summary>Creates a new failed result.</summary>
+	/// <param name="failure">The possible failure.</param>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
-	/// <param name="failure">The possible failure.</param>
 	/// <returns>A new failed result.</returns>
 	public static Result<TSuccess, TFailure> Fail<TSuccess, TFailure>(TFailure failure)
 		=> new(failure);
 
 	/// <summary>Creates a new failed result.</summary>
+	/// <param name="createFailure">Creates the possible failure.</param>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
-	/// <param name="createFailure">Creates the possible failure.</param>
 	/// <returns>A new failed result.</returns>
 	public static Result<TSuccess, TFailure> Fail<TSuccess, TFailure>(Func<TFailure> createFailure)
 		=> new(createFailure());

--- a/test/unit/Monads/Fixtures/ResultFixture.cs
+++ b/test/unit/Monads/Fixtures/ResultFixture.cs
@@ -2,7 +2,7 @@ namespace Daht.Sagitta.Core.UnitTest.Monads.Fixtures;
 
 internal static class ResultFixture
 {
-	internal const string Failure = nameof(ResultFixture.Failure);
+	internal const string Failure = nameof(Failure);
 
 	internal static Constellation Success
 		=> new()
@@ -13,5 +13,5 @@ internal static class ResultFixture
 		};
 
 	internal static string RandomFailure
-		=> $"{ResultFixture.Failure} | {Guid.NewGuid()}";
+		=> $"{Failure} | {Guid.NewGuid()}";
 }

--- a/test/unit/Monads/ResultFactoryTest.cs
+++ b/test/unit/Monads/ResultFactoryTest.cs
@@ -6,6 +6,8 @@ public sealed class ResultFactoryTest
 
 	private const string @catch = nameof(ResultFactory.Catch);
 
+	private const string ensure = nameof(ResultFactory.Ensure);
+
 	private const string succeed = nameof(ResultFactory.Succeed);
 
 	private const string fail = nameof(ResultFactory.Fail);
@@ -13,39 +15,77 @@ public sealed class ResultFactoryTest
 	#region Catch
 
 	[Fact]
-	[Trait(ResultFactoryTest.root, ResultFactoryTest.@catch)]
+	[Trait(root, @catch)]
 	public void Catch_CreateSuccessPlusCreateFailure_SuccessfulResult()
 	{
-		//Arrange
+		// Arrange
 		Constellation expectedSuccess = ResultFixture.Success;
 		Constellation CreateSuccess()
 			=> expectedSuccess;
 		static string CreateFailure(InvalidOperationException exception)
 			=> exception.Message;
 
-		//Act
+		// Act
 		Result<Constellation, string> actualResult = ResultFactory.Catch<InvalidOperationException, Constellation, string>(CreateSuccess, CreateFailure);
 
-		//Assert
+		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
 	}
 
 	[Fact]
-	[Trait(ResultFactoryTest.root, ResultFactoryTest.@catch)]
+	[Trait(root, @catch)]
 	public void Catch_ExceptionPlusCreateFailure_FailedResult()
 	{
-		//Arrange
+		// Arrange
 		static Constellation CreateSuccess()
 			=> throw new InvalidOperationException();
 		static string CreateFailure(InvalidOperationException exception)
 			=> exception.Message;
 		const string expectedFailure = "Operation is not valid due to the current state of the object.";
 
-		//Act
+		// Act
 		Result<Constellation, string> actualResult = ResultFactory.Catch<InvalidOperationException, Constellation, string>(CreateSuccess, CreateFailure);
 
-		//Assert
+		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	#endregion
+
+	#region Ensure
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_SuccessPlusTruePredicatePlusFailure_FailedResult()
+	{
+		// Arrange
+		Constellation success = ResultFixture.Success;
+		static bool Predicate(Constellation _)
+			=> true;
+		const string expectedFailure = ResultFixture.Failure;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultFactory.Ensure(success, Predicate, expectedFailure);
+
+		// Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_SuccessPlusFalsePredicatePlusFailure_SuccessfulResult()
+	{
+		// Arrange
+		Constellation expectedSuccess = ResultFixture.Success;
+		static bool Predicate(Constellation _)
+			=> false;
+		const string failure = ResultFixture.Failure;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultFactory.Ensure(expectedSuccess, Predicate, failure);
+
+		// Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
 	}
 
 	#endregion
@@ -55,16 +95,16 @@ public sealed class ResultFactoryTest
 	#region Overload
 
 	[Fact]
-	[Trait(ResultFactoryTest.root, ResultFactoryTest.succeed)]
+	[Trait(root, succeed)]
 	public void Succeed_Success_SuccessfulResult()
 	{
-		//Arrange
+		// Arrange
 		Constellation expectedSuccess = ResultFixture.Success;
 
-		//Act
+		// Act
 		Result<Constellation, string> actualResult = ResultFactory.Succeed<Constellation, string>(expectedSuccess);
 
-		//Assert
+		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
 	}
 
@@ -73,18 +113,18 @@ public sealed class ResultFactoryTest
 	#region Overload
 
 	[Fact]
-	[Trait(ResultFactoryTest.root, ResultFactoryTest.succeed)]
+	[Trait(root, succeed)]
 	public void Succeed_CreateSuccess_SuccessfulResult()
 	{
-		//Arrange
+		// Arrange
 		Constellation expectedSuccess = ResultFixture.Success;
 		Constellation CreateSuccess()
 			=> expectedSuccess;
 
-		//Act
+		// Act
 		Result<Constellation, string> actualResult = ResultFactory.Succeed<Constellation, string>(CreateSuccess);
 
-		//Assert
+		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
 	}
 
@@ -97,16 +137,16 @@ public sealed class ResultFactoryTest
 	#region Overload
 
 	[Fact]
-	[Trait(ResultFactoryTest.root, ResultFactoryTest.fail)]
+	[Trait(root, fail)]
 	public void Fail_Failure_FailedResult()
 	{
-		//Arrange
+		// Arrange
 		const string expectedFailure = ResultFixture.Failure;
 
-		//Act
+		// Act
 		Result<Constellation, string> actualResult = ResultFactory.Fail<Constellation, string>(expectedFailure);
 
-		//Assert
+		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
 
@@ -115,18 +155,18 @@ public sealed class ResultFactoryTest
 	#region Overload
 
 	[Fact]
-	[Trait(ResultFactoryTest.root, ResultFactoryTest.fail)]
+	[Trait(root, fail)]
 	public void Fail_CreateFailure_FailedResult()
 	{
-		//Arrange
+		// Arrange
 		const string expectedFailure = ResultFixture.Failure;
 		static string CreateFailure()
 			=> expectedFailure;
 
-		//Act
+		// Act
 		Result<Constellation, string> actualResult = ResultFactory.Fail<Constellation, string>(CreateFailure);
 
-		//Assert
+		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
 

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -15,16 +15,16 @@ public sealed class ResultTest
 	#region Overload
 
 	[Fact]
-	[Trait(ResultTest.root, ResultTest.constructor)]
+	[Trait(root, constructor)]
 	public void Constructor_Success_SuccessfulResult()
 	{
-		//Arrange
+		// Arrange
 		Constellation expectedSuccess = ResultFixture.Success;
 
-		//Act
+		// Act
 		Result<Constellation, string> actualResult = new(expectedSuccess);
 
-		//Assert
+		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
 	}
 
@@ -33,16 +33,16 @@ public sealed class ResultTest
 	#region Overload
 
 	[Fact]
-	[Trait(ResultTest.root, ResultTest.constructor)]
+	[Trait(root, constructor)]
 	public void Constructor_Failure_FailedResult()
 	{
-		//Arrange
+		// Arrange
 		const string expectedFailure = ResultFixture.Failure;
 
-		//Act
+		// Act
 		Result<Constellation, string> actualResult = new(expectedFailure);
 
-		//Assert
+		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
 
@@ -55,16 +55,16 @@ public sealed class ResultTest
 	#region Overload
 
 	[Fact]
-	[Trait(ResultTest.root, ResultTest.implicitOperator)]
+	[Trait(root, implicitOperator)]
 	public void ImplicitOperator_Success_SuccessfulResult()
 	{
-		//Arrange
+		// Arrange
 		Constellation expectedSuccess = ResultFixture.Success;
 
-		//Act
+		// Act
 		Result<Constellation, string> actualResult = expectedSuccess;
 
-		//Assert
+		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
 	}
 
@@ -73,16 +73,16 @@ public sealed class ResultTest
 	#region Overload
 
 	[Fact]
-	[Trait(ResultTest.root, ResultTest.implicitOperator)]
+	[Trait(root, implicitOperator)]
 	public void ImplicitOperator_Failure_FailedResult()
 	{
-		//Arrange
+		// Arrange
 		const string expectedFailure = ResultFixture.Failure;
 
-		//Act
+		// Act
 		Result<Constellation, string> actualResult = expectedFailure;
 
-		//Assert
+		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
 
@@ -93,55 +93,55 @@ public sealed class ResultTest
 	#region Ensure
 
 	[Fact]
-	[Trait(ResultTest.root, ResultTest.ensure)]
+	[Trait(root, ensure)]
 	public void Ensure_FailedResultPlusFalsePredicatePlusFailure_FailedResult()
 	{
-		//Arrange
+		// Arrange
 		const string expectedFailure = ResultFixture.Failure;
 		static bool Predicate(Constellation _)
 			=> false;
 		string failure = ResultFixture.RandomFailure;
 
-		//Act
+		// Act
 		Result<Constellation, string> actualResult = ResultMother.Fail(expectedFailure)
 			.Ensure(Predicate, failure);
 
-		//Assert
+		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
 
 	[Fact]
-	[Trait(ResultTest.root, ResultTest.ensure)]
+	[Trait(root, ensure)]
 	public void Ensure_SuccessfulResultPlusTruePredicatePlusFailure_FailedResult()
 	{
-		//Arrange
+		// Arrange
 		static bool Predicate(Constellation _)
 			=> true;
 		const string expectedFailure = ResultFixture.Failure;
 
-		//Act
+		// Act
 		Result<Constellation, string> actualResult = ResultMother.Succeed()
 			.Ensure(Predicate, expectedFailure);
 
-		//Assert
+		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
 
 	[Fact]
-	[Trait(ResultTest.root, ResultTest.ensure)]
+	[Trait(root, ensure)]
 	public void Ensure_SuccessfulResultPlusFalsePredicatePlusFailure_SuccessfulResult()
 	{
-		//Arrange
+		// Arrange
 		Constellation expectedSuccess = ResultFixture.Success;
 		static bool Predicate(Constellation _)
 			=> false;
 		const string failure = ResultFixture.Failure;
 
-		//Act
+		// Act
 		Result<Constellation, string> actualResult = ResultMother.Succeed(expectedSuccess)
 			.Ensure(Predicate, failure);
 
-		//Assert
+		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
 	}
 


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Description <!-- Required -->

The purpose of this change is to extend [ResultFactory](source/Monads/ResultFactory.cs). The details of this new feature are:

- **Type**: [ResultFactory](source/Monads/ResultFactory.cs).
- **Signature**:

  ```cs
    public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(TSuccess success, Func<TSuccess, bool> predicate, TFailure failure)
  ```

- **Member**: Method.
- **Description**: Creates a new failed result if the value of `predicate` is [true](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/true-false-operators); otherwise, returns the previous result.
- **Parameters**:
  - `success`: The expected success.
  - `predicate`: Creates a set of criteria.
  - `failure`: The possible failure.
- **Generics**:
  - `TSuccess`: Type of expected success.
  - `TFailure`: Type of possible failure.

<!-- ## Evidence <!-- Optional -->
