### PR TITLE
feature: add overload of the `Ensure` method

### DIFF
--- a/source/Monads/ResultFactory.cs
+++ b/source/Monads/ResultFactory.cs
@@ -36,6 +36,18 @@ public static class ResultFactory
 			? Fail<TSuccess, TFailure>(failure)
 			: Succeed<TSuccess, TFailure>(success);
 
+	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
+	/// <param name="success">The expected success.</param>
+	/// <param name="predicate">Creates a set of criteria.</param>
+	/// <param name="createFailure">Creates the possible failure.</param>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
+	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
+	public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(TSuccess success, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)
+		=> predicate(success)
+			? Fail<TSuccess, TFailure>(createFailure(success))
+			: Succeed<TSuccess, TFailure>(success);
+
 	/// <summary>Creates a new successful result.</summary>
 	/// <param name="success">The expected success.</param>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>

--- a/test/unit/Monads/ResultFactoryTest.cs
+++ b/test/unit/Monads/ResultFactoryTest.cs
@@ -54,6 +54,8 @@ public sealed class ResultFactoryTest
 
 	#region Ensure
 
+	#region Overload
+
 	[Fact]
 	[Trait(root, ensure)]
 	public void Ensure_SuccessPlusTruePredicatePlusFailure_FailedResult()
@@ -87,6 +89,49 @@ public sealed class ResultFactoryTest
 		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
 	}
+
+	#endregion
+
+	#region Overload
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_SuccessPlusTruePredicatePlusCreateFailure_FailedResult()
+	{
+		// Arrange
+		Constellation success = ResultFixture.Success;
+		static bool Predicate(Constellation _)
+			=> true;
+		const string expectedFailure = ResultFixture.Failure;
+		static string CreateFailure(Constellation _)
+			=> expectedFailure;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultFactory.Ensure(success, Predicate, CreateFailure);
+
+		// Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_SuccessPlusFalsePredicatePlusCreateFailure_SuccessfulResult()
+	{
+		// Arrange
+		Constellation expectedSuccess = ResultFixture.Success;
+		static bool Predicate(Constellation _)
+			=> false;
+		static string CreateFailure(Constellation _)
+			=> ResultFixture.Failure;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultFactory.Ensure(expectedSuccess, Predicate, CreateFailure);
+
+		// Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
+
+	#endregion
 
 	#endregion
 


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Description <!-- Required -->

The purpose of this change is to extend [ResultFactory](source/Monads/ResultFactory.cs). The details of this new feature are:

- **Type**: [ResultFactory](source/Monads/ResultFactory.cs).
- **Signature**:

  ```cs
    public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(TSuccess success, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)
  ```

- **Member**: Method.
- **Description**: Creates a new failed result if the value of `predicate` is [true](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/true-false-operators); otherwise, returns the previous result.
- **Parameters**:
  - `success`: The expected success.
  - `predicate`: Creates a set of criteria.
  - `createFailure`: Creates the possible failure.
- **Generics**:
  - `TSuccess`: Type of expected success.
  - `TFailure`: Type of possible failure.

<!-- ## Evidence <!-- Optional -->
