### PR TITLE
feature(`ResultFactory`): add overload of the `Ensure` method

### DIFF
--- a/source/Monads/ResultFactory.cs
+++ b/source/Monads/ResultFactory.cs
@@ -63,6 +63,21 @@ public static class ResultFactory
 			: Succeed<TSuccess, TFailure>(success);
 	}
 
+	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
+	/// <param name="createSuccess">Creates the expected success.</param>
+	/// <param name="predicate">Creates a set of criteria.</param>
+	/// <param name="createFailure">Creates the possible failure.</param>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
+	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
+	public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(Func<TSuccess> createSuccess, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)
+	{
+		TSuccess success = createSuccess();
+		return predicate(success)
+			? Fail<TSuccess, TFailure>(createFailure(success))
+			: Succeed<TSuccess, TFailure>(success);
+	}
+
 	/// <summary>Creates a new successful result.</summary>
 	/// <param name="success">The expected success.</param>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>

--- a/test/unit/Monads/ResultFactoryTest.cs
+++ b/test/unit/Monads/ResultFactoryTest.cs
@@ -174,6 +174,50 @@ public sealed class ResultFactoryTest
 
 	#endregion
 
+	#region Overload
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_CreateSuccessPlusTruePredicatePlusCreateFailure_FailedResult()
+	{
+		// Arrange
+		static Constellation CreateSuccess()
+			=> ResultFixture.Success;
+		static bool Predicate(Constellation _)
+			=> true;
+		const string expectedFailure = ResultFixture.Failure;
+		static string CreateFailure(Constellation _)
+			=> expectedFailure;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultFactory.Ensure(CreateSuccess, Predicate, CreateFailure);
+
+		// Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_CreateSuccessPlusFalsePredicatePlusCreateFailure_SuccessfulResult()
+	{
+		// Arrange
+		Constellation expectedSuccess = ResultFixture.Success;
+		Constellation CreateSuccess()
+			=> expectedSuccess;
+		static bool Predicate(Constellation _)
+			=> false;
+		static string CreateFailure(Constellation _)
+			=> ResultFixture.Failure;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultFactory.Ensure(CreateSuccess, Predicate, CreateFailure);
+
+		// Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
+
+	#endregion
+
 	#endregion
 
 	#region Succeed


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Description <!-- Required -->

The purpose of this change is to extend [ResultFactory](source/Monads/ResultFactory.cs). The details of this new feature are:

- **Type**: [ResultFactory](source/Monads/ResultFactory.cs).
- **Signature**:

  ```cs
    public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(Func<TSuccess> createSuccess, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)
  ```

- **Member**: Method.
- **Description**: Creates a new failed result if the value of `predicate` is [true](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/true-false-operators); otherwise, returns the previous result.
- **Parameters**:
  - `createSuccess`: Creates the expected success.
  - `predicate`: Creates a set of criteria.
  - `createFailure`: Creates the possible failure.
- **Generics**:
  - `TSuccess`: Type of expected success.
  - `TFailure`: Type of possible failure.

<!-- ## Evidence <!-- Optional -->
