### PR TITLE
feature(`ResultFactory`): add overload of the `Ensure` method

### DIFF
--- a/source/Monads/ResultFactory.cs
+++ b/source/Monads/ResultFactory.cs
@@ -92,6 +92,23 @@ public static class ResultFactory
 			? Fail<TSuccess, TFailure>(createFailure(success, auxiliary))
 			: Succeed<TSuccess, TFailure>(success);
 
+	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
+	/// <param name="success">The expected success.</param>
+	/// <param name="createAuxiliary">Creates the auxiliary to use in combination with <paramref name="predicate" /> and <paramref name="createFailure" />.</param>
+	/// <param name="predicate">Creates a set of criteria.</param>
+	/// <param name="createFailure">Creates the possible failure.</param>
+	/// <typeparam name="TAuxiliary">Type of auxiliary.</typeparam>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
+	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
+	public static Result<TSuccess, TFailure> Ensure<TAuxiliary, TSuccess, TFailure>(TSuccess success, Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
+	{
+		TAuxiliary auxiliary = createAuxiliary();
+		return predicate(success, auxiliary)
+			? Fail<TSuccess, TFailure>(createFailure(success, auxiliary))
+			: Succeed<TSuccess, TFailure>(success);
+	}
+
 	/// <summary>Creates a new successful result.</summary>
 	/// <param name="success">The expected success.</param>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>

--- a/test/unit/Monads/ResultFactoryTest.cs
+++ b/test/unit/Monads/ResultFactoryTest.cs
@@ -237,6 +237,45 @@ public sealed class ResultFactoryTest
 
 	#endregion
 
+	#region Overlaod
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_SuccessPlusCreateAuxiliaryPlusTruePredicatePlusCreateFailure_FailedResult()
+	{
+		// Arrange
+		Constellation success = ResultFixture.Success;
+		Func<string> createAuxiliary = static () => ResultFixture.Auxiliary;
+		Func<Constellation, string, bool> predicate = static (_, _) => true;
+		const string expectedFailure = ResultFixture.Failure;
+		Func<Constellation, string, string> createFailure = static (_, _) => expectedFailure;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultFactory.Ensure(success, createAuxiliary, predicate, createFailure);
+
+		// Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_SuccessPlusCreateAuxiliaryPlusFalsePredicatePlusCreateFailure_SuccessfulResult()
+	{
+		// Arrange
+		Constellation expectedSuccess = ResultFixture.Success;
+		Func<string> createAuxiliary = static () => ResultFixture.Auxiliary;
+		Func<Constellation, string, bool> predicate = static (_, _) => false;
+		Func<Constellation, string, string> createFailure = static (_, _) => ResultFixture.Failure;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultFactory.Ensure(expectedSuccess, createAuxiliary, predicate, createFailure);
+
+		// Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
+
+	#endregion
+
 	#endregion
 
 	#region Succeed


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Description <!-- Required -->

The purpose of this change is to extend [ResultFactory](source/Monads/ResultFactory.cs). The details of this new feature are:

- **Type**: [ResultFactory](source/Monads/ResultFactory.cs).
- **Signature**:

  ```cs
    public static Result<TSuccess, TFailure> Ensure<TAuxiliary, TSuccess, TFailure>(TSuccess success, Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
  ```

- **Member**: Method.
- **Description**: Creates a new failed result if the value of `predicate` is [true](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/true-false-operators); otherwise, returns the previous result.
- **Parameters**:
  - `success`: The expected success.
  - `createAuxiliary`: Creates the auxiliary to use in combination with `predicate` and `createFailure`.
  - `predicate`: Creates a set of criteria.
  - `createFailure`: Creates the possible failure.
- **Generics**:
  - `TAuxiliary`: Type of auxiliary.
  - `TSuccess`: Type of expected success.
  - `TFailure`: Type of possible failure.

<!-- ## Evidence <!-- Optional -->
