### PR TITLE
feature(`Result`): add overload of the `Ensure` method

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -57,7 +57,22 @@ public sealed class Result<TSuccess, TFailure>
 			return this;
 		}
 		return predicate(Success)
-			? new(failure)
+			? ResultFactory.Fail<TSuccess, TFailure>(failure)
+			: this;
+	}
+
+	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
+	/// <param name="predicate">Creates a set of criteria.</param>
+	/// <param name="createFailure">Creates the possible failure.</param>
+	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
+	public Result<TSuccess, TFailure> Ensure(Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)
+	{
+		if (IsFailed)
+		{
+			return this;
+		}
+		return predicate(Success)
+			? ResultFactory.Fail<TSuccess, TFailure>(createFailure(Success))
 			: this;
 	}
 }

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -92,6 +92,8 @@ public sealed class ResultTest
 
 	#region Ensure
 
+	#region Overload
+
 	[Fact]
 	[Trait(root, ensure)]
 	public void Ensure_FailedResultPlusTruePredicatePlusFailure_FailedResult()
@@ -141,6 +143,63 @@ public sealed class ResultTest
 		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
 	}
+
+	#endregion
+
+	#region Overload
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_FailedResultPlusTruePredicatePlusCreateFailure_FailedResult()
+	{
+		// Arrange
+		const string expectedFailure = ResultFixture.Failure;
+		Func<Constellation, bool> predicate = static _ => true;
+		Func<Constellation, string> createFailure = static _ => ResultFixture.RandomFailure;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultMother.Fail(expectedFailure)
+			.Ensure(predicate, createFailure);
+
+		// Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_SuccessfulResultPlusTruePredicatePlusCreateFailure_FailedResult()
+	{
+		// Arrange
+		Func<Constellation, bool> predicate = static _ => true;
+		const string expectedFailure = ResultFixture.Failure;
+		Func<Constellation, string> createFailure = static _ => expectedFailure;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultMother.Succeed()
+			.Ensure(predicate, createFailure);
+
+		// Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_SuccessfulResultPlusFalsePredicatePlusCreateFailure_SuccessfulResult()
+	{
+		// Arrange
+		Constellation expectedSuccess = ResultFixture.Success;
+		Func<Constellation, bool> predicate = static _ => false;
+		Func<Constellation, string> createFailure = static _ => ResultFixture.Failure;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultMother.Succeed(expectedSuccess)
+			.Ensure(predicate, createFailure);
+
+		// Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
+
+	#endregion
 
 	#endregion
 }


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Description <!-- Required -->

The purpose of this change is to extend [Result<TSuccess, TFailure>](source/Monads/Result.cs). The details of this new feature are:

- **Type**: [Result<TSuccess, TFailure>](source/Monads/Result.cs).
- **Signature**:

  ```cs
    public Result<TSuccess, TFailure> Ensure(Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)
  ```

- **Member**: Method.
- **Description**: Creates a new failed result if the value of `predicate` is [true](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/true-false-operators); otherwise, returns the previous result.
- **Parameters**:
  - `predicate`: Creates a set of criteria.
  - `createFailure`: Creates the possible failure.

<!-- ## Evidence <!-- Optional -->
