### PR TITLE
feature(`Result`): add overload of the `Ensure` method

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -92,5 +92,23 @@ public sealed class Result<TSuccess, TFailure>
 			? new(createFailure(Success, auxiliary))
 			: this;
 	}
+
+	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
+	/// <param name="createAuxiliary">Creates the auxiliary to use in combination with <paramref name="predicate" /> and <paramref name="createFailure" />.</param>
+	/// <param name="predicate">Creates a set of criteria.</param>
+	/// <param name="createFailure">Creates the possible failure.</param>
+	/// <typeparam name="TAuxiliary">Type of auxiliary.</typeparam>
+	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
+	public Result<TSuccess, TFailure> Ensure<TAuxiliary>(Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
+	{
+		if (IsFailed)
+		{
+			return this;
+		}
+		TAuxiliary auxiliary = createAuxiliary();
+		return predicate(Success, auxiliary)
+			? new(createFailure(Success, auxiliary))
+			: this;
+	}
 }
 #pragma warning restore CA1062

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -259,5 +259,63 @@ public sealed class ResultTest
 
 	#endregion
 
+	#region Overload
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_FailedResultPlusCreateAuxiliaryPlusTruePredicatePlusCreateFailure_FailedResult()
+	{
+		// Arrange
+		const string expectedFailure = ResultFixture.Failure;
+		Func<string> createAuxiliary = static () => ResultFixture.Auxiliary;
+		Func<Constellation, string, bool> predicate = static (_, _) => true;
+		Func<Constellation, string, string> createFailure = static (_, _) => ResultFixture.RandomFailure;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultMother.Fail(expectedFailure)
+			.Ensure(createAuxiliary, predicate, createFailure);
+
+		// Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_SuccessfulResultPlusCreateAuxiliaryPlusTruePredicatePlusCreateFailure_FailedResult()
+	{
+		// Arrange
+		Func<string> createAuxiliary = static () => ResultFixture.Auxiliary;
+		Func<Constellation, string, bool> predicate = static (_, _) => true;
+		const string expectedFailure = ResultFixture.Failure;
+		Func<Constellation, string, string> createFailure = static (_, _) => expectedFailure;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultMother.Succeed()
+			.Ensure(createAuxiliary, predicate, createFailure);
+
+		// Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_SuccessfulResultPlusCreateAuxiliaryPlusFalsePredicatePlusCreateFailure_SuccessfulResult()
+	{
+		// Arrange
+		Constellation expectedSuccess = ResultFixture.Success;
+		Func<string> createAuxiliary = static () => ResultFixture.Auxiliary;
+		Func<Constellation, string, bool> predicate = static (_, _) => false;
+		Func<Constellation, string, string> createFailure = static (_, _) => ResultFixture.Failure;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultMother.Succeed(expectedSuccess)
+			.Ensure(createAuxiliary, predicate, createFailure);
+
+		// Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
+
+	#endregion
+
 	#endregion
 }


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Description <!-- Required -->

The purpose of this change is to extend [Result<TSuccess, TFailure>](source/Monads/Result.cs). The details of this new feature are:

- **Type**: [Result<TSuccess, TFailure>](source/Monads/Result.cs).
- **Signature**:

  ```cs
    public Result<TSuccess, TFailure> Ensure<TAuxiliary>(Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
  ```

- **Member**: Method.
- **Description**: Creates a new failed result if the value of `predicate` is [true](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/true-false-operators); otherwise, returns the previous result.
- **Parameters**:
  - `createAuxiliary`: Creates the auxiliary to use in combination with `predicate` and `createFailure`.
  - `predicate`: Creates a set of criteria.
  - `createFailure`: Creates the possible failure.
- **Generics**:
  - `TAuxiliary`: Type of auxiliary.

<!-- ## Evidence <!-- Optional -->
