### PR TITLE
feature(`Result`): add `Map` method

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -110,5 +110,14 @@ public sealed class Result<TSuccess, TFailure>
 			? new(createFailure(Success, auxiliary))
 			: this;
 	}
+
+	/// <summary>Creates a new result with a different expected success.</summary>
+	/// <param name="successToMap">The expected success to map.</param>
+	/// <typeparam name="TSuccessToMap">Type of expected success to map.</typeparam>
+	/// <returns>A new result with a different expected success.</returns>
+	public Result<TSuccessToMap, TFailure> Map<TSuccessToMap>(TSuccessToMap successToMap)
+		=> IsFailed
+			? new(Failure)
+			: new(successToMap);
 }
 #pragma warning restore CA1062

--- a/test/unit/Monads/Fixtures/ResultFixture.cs
+++ b/test/unit/Monads/Fixtures/ResultFixture.cs
@@ -9,9 +9,18 @@ internal static class ResultFixture
 	internal static Constellation Success
 		=> new()
 		{
+			Galaxy = "Milky Way",
 			Abbreviation = "Sge",
 			Name = "Sagitta",
 			Symbolism = "The arrow"
+		};
+
+	internal static Start SuccessToMap
+		=> new()
+		{
+			Constellation = Success.Name,
+			Name = "Gamma Sagittae",
+			EvolutionaryStage = "Red Giant"
 		};
 
 	internal static string RandomFailure

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -10,6 +10,8 @@ public sealed class ResultTest
 
 	private const string ensure = nameof(Result<object, object>.Ensure);
 
+	private const string map = nameof(Result<object, object>.Map);
+
 	#region Constructor
 
 	#region Overload
@@ -316,6 +318,41 @@ public sealed class ResultTest
 	}
 
 	#endregion
+
+	#endregion
+
+	#region Map
+
+	[Fact]
+	[Trait(root, map)]
+	public void Map_FailedResultPlusSuccessToMap_FailedResult()
+	{
+		//Arrange
+		const string expectedFailure = ResultFixture.Failure;
+		Start successToMap = ResultFixture.SuccessToMap;
+
+		//Act
+		Result<Start, string> actualResult = ResultMother.Fail(expectedFailure)
+			.Map(successToMap);
+
+		//Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, map)]
+	public void Map_SuccessfulResultPlusSuccessToMap_SuccessfulResult()
+	{
+		//Arrange
+		Start expectedSuccess = ResultFixture.SuccessToMap;
+
+		//Act
+		Result<Start, string> actualResult = ResultMother.Succeed()
+			.Map(expectedSuccess);
+
+		//Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
 
 	#endregion
 }

--- a/test/unit/Shared/Fakers/Constellation.cs
+++ b/test/unit/Shared/Fakers/Constellation.cs
@@ -2,6 +2,8 @@ namespace Daht.Sagitta.Core.UnitTest.Shared.Fakers;
 
 internal sealed record Constellation
 {
+	internal required string Galaxy { get; init; }
+
 	internal required string Abbreviation { get; init; }
 
 	internal required string Name { get; init; }

--- a/test/unit/Shared/Fakers/Start.cs
+++ b/test/unit/Shared/Fakers/Start.cs
@@ -1,0 +1,10 @@
+namespace Daht.Sagitta.Core.UnitTest.Shared.Fakers;
+
+internal sealed record Start
+{
+	internal required string Constellation { get; init; }
+
+	internal required string Name { get; init; }
+
+	internal required string EvolutionaryStage { get; init; }
+}


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Description <!-- Required -->

The purpose of this change is to extend [Result<TSuccess, TFailure>](source/Monads/Result.cs). The details of this new feature are:

- **Type**: [Result<TSuccess, TFailure>](source/Monads/Result.cs).
- **Signature**:

  ```cs
    public Result<TSuccessToMap, TFailure> Map<TSuccessToMap>(TSuccessToMap successToMap)
  ```

- **Member**: Method.
- **Description**: Creates a new result with a different expected success.
- **Parameters**:
  - `successToMap`: The expected success to map.
- **Generics**:
  - `TSuccessToMap`: Type of expected success to map.

<!-- ## Evidence <!-- Optional -->
