### PR TITLE
feature(`Result`): add overload of the `Map` method

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -119,5 +119,14 @@ public sealed class Result<TSuccess, TFailure>
 		=> IsFailed
 			? new(Failure)
 			: new(successToMap);
+
+	/// <summary>Creates a new result with a different expected success.</summary>
+	/// <param name="createSuccessToMap">Creates the expected success to map.</param>
+	/// <typeparam name="TSuccessToMap">Type of expected success to map.</typeparam>
+	/// <returns>A new result with a different expected success.</returns>
+	public Result<TSuccessToMap, TFailure> Map<TSuccessToMap>(Func<TSuccess, TSuccessToMap> createSuccessToMap)
+		=> IsFailed
+			? new(Failure)
+			: new(createSuccessToMap(Success));
 }
 #pragma warning restore CA1062

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -323,6 +323,8 @@ public sealed class ResultTest
 
 	#region Map
 
+	#region Overload
+
 	[Fact]
 	[Trait(root, map)]
 	public void Map_FailedResultPlusSuccessToMap_FailedResult()
@@ -353,6 +355,44 @@ public sealed class ResultTest
 		//Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
 	}
+
+	#endregion
+
+	#region Overload
+
+	[Fact]
+	[Trait(root, map)]
+	public void Map_FailedResultPlusCreateSuccessToMap_FailedResult()
+	{
+		//Arrange
+		const string expectedFailure = ResultFixture.Failure;
+		Func<Constellation, Start> createSuccessToMap = static _ => ResultFixture.SuccessToMap;
+
+		//Act
+		Result<Start, string> actualResult = ResultMother.Fail(expectedFailure)
+			.Map(createSuccessToMap);
+
+		//Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, map)]
+	public void Map_SuccessfulResultPlusCreateSuccessToMap_SuccessfulResult()
+	{
+		//Arrange
+		Start expectedSuccess = ResultFixture.SuccessToMap;
+		Func<Constellation, Start> createSuccessToMap = _ => expectedSuccess;
+
+		//Act
+		Result<Start, string> actualResult = ResultMother.Succeed()
+			.Map(createSuccessToMap);
+
+		//Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
+
+	#endregion
 
 	#endregion
 }


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Description <!-- Required -->

The purpose of this change is to extend [Result<TSuccess, TFailure>](source/Monads/Result.cs). The details of this new feature are:

- **Type**: [Result<TSuccess, TFailure>](source/Monads/Result.cs).
- **Signature**:

  ```cs
    public Result<TSuccessToMap, TFailure> Map<TSuccessToMap>(Func<TSuccess, TSuccessToMap> createSuccessToMap)
  ```

- **Member**: Method.
- **Description**: Creates a new result with a different expected success.
- **Parameters**:
  - `createSuccessToMap`: Creates the expected success to map.
- **Generics**:
  - `TSuccessToMap`: Type of expected success to map.

<!-- ## Evidence <!-- Optional -->
