### PR TITLE
feature(`Result`): add `Bind` method

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -111,22 +111,31 @@ public sealed class Result<TSuccess, TFailure>
 			: this;
 	}
 
-	/// <summary>Creates a new result with a different expected success.</summary>
+	/// <summary>Creates a new result with the same or different type of expected success.</summary>
 	/// <param name="successToMap">The expected success to map.</param>
 	/// <typeparam name="TSuccessToMap">Type of expected success to map.</typeparam>
-	/// <returns>A new result with a different expected success.</returns>
+	/// <returns>A new result with the same or different type of expected success.</returns>
 	public Result<TSuccessToMap, TFailure> Map<TSuccessToMap>(TSuccessToMap successToMap)
 		=> IsFailed
 			? new(Failure)
 			: new(successToMap);
 
-	/// <summary>Creates a new result with a different expected success.</summary>
+	/// <summary>Creates a new result with the same or different type of expected success.</summary>
 	/// <param name="createSuccessToMap">Creates the expected success to map.</param>
 	/// <typeparam name="TSuccessToMap">Type of expected success to map.</typeparam>
-	/// <returns>A new result with a different expected success.</returns>
+	/// <returns>A new result with the same or different type of expected success.</returns>
 	public Result<TSuccessToMap, TFailure> Map<TSuccessToMap>(Func<TSuccess, TSuccessToMap> createSuccessToMap)
 		=> IsFailed
 			? new(Failure)
 			: new(createSuccessToMap(Success));
+
+	/// <summary>Creates a new result in combination with another result with the same or different type of expected success.</summary>
+	/// <param name="createResultToBind">Creates a new result to bind.</param>
+	/// <typeparam name="TSuccessToBind">Type of expected success to bind.</typeparam>
+	/// <returns>A new result in combination with another result with the same or different type of expected success.</returns>
+	public Result<TSuccessToBind, TFailure> Bind<TSuccessToBind>(Func<TSuccess, Result<TSuccessToBind, TFailure>> createResultToBind)
+		=> IsFailed
+			? new(Failure)
+			: createResultToBind(Success);
 }
 #pragma warning restore CA1062

--- a/test/unit/Monads/Fixtures/ResultFixture.cs
+++ b/test/unit/Monads/Fixtures/ResultFixture.cs
@@ -15,6 +15,12 @@ internal static class ResultFixture
 			Symbolism = "The arrow"
 		};
 
+	internal static Constellation RandomSuccess
+		=> Success with
+		{
+			Abbreviation = $"{Success.Name} | {Guid.NewGuid()}"
+		};
+
 	internal static Start SuccessToMap
 		=> new()
 		{

--- a/test/unit/Monads/Mothers/ResultMother.cs
+++ b/test/unit/Monads/Mothers/ResultMother.cs
@@ -3,11 +3,14 @@ namespace Daht.Sagitta.Core.UnitTest.Monads.Mothers;
 internal static class ResultMother
 {
 	internal static Result<Constellation, string> Succeed()
-		=> ResultFactory.Succeed<Constellation, string>(ResultFixture.Success);
+		=> new(ResultFixture.Success);
 
 	internal static Result<Constellation, string> Succeed(Constellation success)
-		=> ResultFactory.Succeed<Constellation, string>(success);
+		=> new(success);
+
+	internal static Result<Constellation, string> SucceedRandomly()
+		=> new(ResultFixture.RandomSuccess);
 
 	internal static Result<Constellation, string> Fail(string failure)
-		=> ResultFactory.Fail<Constellation, string>(failure);
+		=> new(failure);
 }

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -12,6 +12,8 @@ public sealed class ResultTest
 
 	private const string map = nameof(Result<object, object>.Map);
 
+	private const string bind = nameof(Result<object, object>.Bind);
+
 	#region Constructor
 
 	#region Overload
@@ -329,15 +331,15 @@ public sealed class ResultTest
 	[Trait(root, map)]
 	public void Map_FailedResultPlusSuccessToMap_FailedResult()
 	{
-		//Arrange
+		// Arrange
 		const string expectedFailure = ResultFixture.Failure;
 		Start successToMap = ResultFixture.SuccessToMap;
 
-		//Act
+		// Act
 		Result<Start, string> actualResult = ResultMother.Fail(expectedFailure)
 			.Map(successToMap);
 
-		//Assert
+		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
 
@@ -345,14 +347,14 @@ public sealed class ResultTest
 	[Trait(root, map)]
 	public void Map_SuccessfulResultPlusSuccessToMap_SuccessfulResult()
 	{
-		//Arrange
+		// Arrange
 		Start expectedSuccess = ResultFixture.SuccessToMap;
 
-		//Act
+		// Act
 		Result<Start, string> actualResult = ResultMother.Succeed()
 			.Map(expectedSuccess);
 
-		//Assert
+		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
 	}
 
@@ -364,15 +366,15 @@ public sealed class ResultTest
 	[Trait(root, map)]
 	public void Map_FailedResultPlusCreateSuccessToMap_FailedResult()
 	{
-		//Arrange
+		// Arrange
 		const string expectedFailure = ResultFixture.Failure;
 		Func<Constellation, Start> createSuccessToMap = static _ => ResultFixture.SuccessToMap;
 
-		//Act
+		// Act
 		Result<Start, string> actualResult = ResultMother.Fail(expectedFailure)
 			.Map(createSuccessToMap);
 
-		//Assert
+		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
 
@@ -380,19 +382,71 @@ public sealed class ResultTest
 	[Trait(root, map)]
 	public void Map_SuccessfulResultPlusCreateSuccessToMap_SuccessfulResult()
 	{
-		//Arrange
+		// Arrange
 		Start expectedSuccess = ResultFixture.SuccessToMap;
 		Func<Constellation, Start> createSuccessToMap = _ => expectedSuccess;
 
-		//Act
+		// Act
 		Result<Start, string> actualResult = ResultMother.Succeed()
 			.Map(createSuccessToMap);
 
-		//Assert
+		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
 	}
 
 	#endregion
+
+	#endregion
+
+	#region Bind
+
+	[Fact]
+	[Trait(root, bind)]
+	public void Bind_FailedResultPlusCreateResultToBindWithSuccessfulResult_FailedResult()
+	{
+		// Arrange
+		const string expectedFailure = ResultFixture.Failure;
+		Func<Constellation, Result<Constellation, string>> createResultToBind = static _ => ResultMother.Succeed();
+
+		// Act
+		Result<Constellation, string> actualResult = ResultMother.Fail(expectedFailure)
+			.Bind(createResultToBind);
+
+		// Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, bind)]
+	public void Bind_SuccessfulResultPlusCreateResultToBindWithFailedResult_FailedResult()
+	{
+		// Arrange
+		const string expectedFailure = ResultFixture.Failure;
+		Func<Constellation, Result<Constellation, string>> createResultToBind = static _ => ResultMother.Fail(expectedFailure);
+
+		// Act
+		Result<Constellation, string> actualResult = ResultMother.Succeed()
+			.Bind(createResultToBind);
+
+		// Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, bind)]
+	public void Bind_SuccessfulResultPlusCreateResultToBindWithSuccessfulResult_SuccessfulResult()
+	{
+		// Arrange
+		Constellation expectedSuccess = ResultFixture.Success;
+		Func<Constellation, Result<Constellation, string>> createResultToBind = _ => ResultMother.Succeed(expectedSuccess);
+
+		// Act
+		Result<Constellation, string> actualResult = ResultMother.SucceedRandomly()
+			.Bind(createResultToBind);
+
+		// Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
 
 	#endregion
 }


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Description <!-- Required -->

The purpose of this change is to extend [Result<TSuccess, TFailure>](source/Monads/Result.cs). The details of this new feature are:

- **Type**: [Result<TSuccess, TFailure>](source/Monads/Result.cs).
- **Signature**:

  ```cs
    public Result<TSuccessToBind, TFailure> Bind<TSuccessToBind>(Func<TSuccess, Result<TSuccessToBind, TFailure>> createResultToBind)
  ```

- **Member**: Method.
- **Description**: Creates a new result in combination with another result with the same or different type of expected success.
- **Parameters**:
  - `createResultToBind`: Creates a new result to bind.
- **Generics**:
  - `TSuccessToBind`: Type of expected success to bind.

<!-- ## Evidence <!-- Optional -->
