### PR TITLE
refactor: remove all redundant implementations of method overloads

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -48,6 +48,13 @@ public sealed class Result<TSuccess, TFailure>
 
 	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
 	/// <param name="predicate">Creates a set of criteria.</param>
+	/// <param name="createFailure">Creates the possible failure.</param>
+	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
+	public Result<TSuccess, TFailure> Ensure(Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)
+		=> Ensure(predicate, createFailure(Success));
+
+	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
+	/// <param name="predicate">Creates a set of criteria.</param>
 	/// <param name="failure">The possible failure.</param>
 	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
 	public Result<TSuccess, TFailure> Ensure(Func<TSuccess, bool> predicate, TFailure failure)
@@ -62,19 +69,13 @@ public sealed class Result<TSuccess, TFailure>
 	}
 
 	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
+	/// <param name="createAuxiliary">Creates the auxiliary to use in combination with <paramref name="predicate" /> and <paramref name="createFailure" />.</param>
 	/// <param name="predicate">Creates a set of criteria.</param>
 	/// <param name="createFailure">Creates the possible failure.</param>
+	/// <typeparam name="TAuxiliary">Type of auxiliary.</typeparam>
 	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
-	public Result<TSuccess, TFailure> Ensure(Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)
-	{
-		if (IsFailed)
-		{
-			return this;
-		}
-		return predicate(Success)
-			? new(createFailure(Success))
-			: this;
-	}
+	public Result<TSuccess, TFailure> Ensure<TAuxiliary>(Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
+		=> Ensure(createAuxiliary(), predicate, createFailure);
 
 	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
 	/// <param name="auxiliary">The auxiliary to use in combination with <paramref name="predicate" /> and <paramref name="createFailure" />.</param>
@@ -93,23 +94,12 @@ public sealed class Result<TSuccess, TFailure>
 			: this;
 	}
 
-	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
-	/// <param name="createAuxiliary">Creates the auxiliary to use in combination with <paramref name="predicate" /> and <paramref name="createFailure" />.</param>
-	/// <param name="predicate">Creates a set of criteria.</param>
-	/// <param name="createFailure">Creates the possible failure.</param>
-	/// <typeparam name="TAuxiliary">Type of auxiliary.</typeparam>
-	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
-	public Result<TSuccess, TFailure> Ensure<TAuxiliary>(Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
-	{
-		if (IsFailed)
-		{
-			return this;
-		}
-		TAuxiliary auxiliary = createAuxiliary();
-		return predicate(Success, auxiliary)
-			? new(createFailure(Success, auxiliary))
-			: this;
-	}
+	/// <summary>Creates a new result with the same or different type of expected success.</summary>
+	/// <param name="createSuccessToMap">Creates the expected success to map.</param>
+	/// <typeparam name="TSuccessToMap">Type of expected success to map.</typeparam>
+	/// <returns>A new result with the same or different type of expected success.</returns>
+	public Result<TSuccessToMap, TFailure> Map<TSuccessToMap>(Func<TSuccess, TSuccessToMap> createSuccessToMap)
+		=> Map(createSuccessToMap(Success));
 
 	/// <summary>Creates a new result with the same or different type of expected success.</summary>
 	/// <param name="successToMap">The expected success to map.</param>
@@ -119,15 +109,6 @@ public sealed class Result<TSuccess, TFailure>
 		=> IsFailed
 			? new(Failure)
 			: new(successToMap);
-
-	/// <summary>Creates a new result with the same or different type of expected success.</summary>
-	/// <param name="createSuccessToMap">Creates the expected success to map.</param>
-	/// <typeparam name="TSuccessToMap">Type of expected success to map.</typeparam>
-	/// <returns>A new result with the same or different type of expected success.</returns>
-	public Result<TSuccessToMap, TFailure> Map<TSuccessToMap>(Func<TSuccess, TSuccessToMap> createSuccessToMap)
-		=> IsFailed
-			? new(Failure)
-			: new(createSuccessToMap(Success));
 
 	/// <summary>Creates a new result in combination with another result with the same or different type of expected success.</summary>
 	/// <param name="createResultToBind">Creates a new result to bind.</param>

--- a/source/Monads/ResultFactory.cs
+++ b/source/Monads/ResultFactory.cs
@@ -27,6 +27,36 @@ public static class ResultFactory
 	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
 	/// <param name="success">The expected success.</param>
 	/// <param name="predicate">Creates a set of criteria.</param>
+	/// <param name="createFailure">Creates the possible failure.</param>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
+	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
+	public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(TSuccess success, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)
+		=> Ensure(success, predicate, createFailure(success));
+
+	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
+	/// <param name="createSuccess">Creates the expected success.</param>
+	/// <param name="predicate">Creates a set of criteria.</param>
+	/// <param name="createFailure">Creates the possible failure.</param>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
+	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
+	public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(Func<TSuccess> createSuccess, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)
+		=> Ensure(createSuccess(), predicate, createFailure);
+
+	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
+	/// <param name="createSuccess">Creates the expected success.</param>
+	/// <param name="predicate">Creates a set of criteria.</param>
+	/// <param name="failure">The possible failure.</param>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
+	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
+	public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(Func<TSuccess> createSuccess, Func<TSuccess, bool> predicate, TFailure failure)
+		=> Ensure(createSuccess(), predicate, failure);
+
+	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
+	/// <param name="success">The expected success.</param>
+	/// <param name="predicate">Creates a set of criteria.</param>
 	/// <param name="failure">The possible failure.</param>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
@@ -38,45 +68,39 @@ public static class ResultFactory
 
 	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
 	/// <param name="success">The expected success.</param>
+	/// <param name="createAuxiliary">Creates the auxiliary to use in combination with <paramref name="predicate" /> and <paramref name="createFailure" />.</param>
 	/// <param name="predicate">Creates a set of criteria.</param>
 	/// <param name="createFailure">Creates the possible failure.</param>
+	/// <typeparam name="TAuxiliary">Type of auxiliary.</typeparam>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
 	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
-	public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(TSuccess success, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)
-		=> predicate(success)
-			? Fail<TSuccess, TFailure>(createFailure(success))
-			: Succeed<TSuccess, TFailure>(success);
+	public static Result<TSuccess, TFailure> Ensure<TAuxiliary, TSuccess, TFailure>(TSuccess success, Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
+		=> Ensure(success, createAuxiliary(), predicate, createFailure);
 
 	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
 	/// <param name="createSuccess">Creates the expected success.</param>
+	/// <param name="createAuxiliary">Creates the auxiliary to use in combination with <paramref name="predicate" /> and <paramref name="createFailure" />.</param>
 	/// <param name="predicate">Creates a set of criteria.</param>
-	/// <param name="failure">The possible failure.</param>
+	/// <param name="createFailure">Creates the possible failure.</param>
+	/// <typeparam name="TAuxiliary">Type of auxiliary.</typeparam>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
 	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
-	public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(Func<TSuccess> createSuccess, Func<TSuccess, bool> predicate, TFailure failure)
-	{
-		TSuccess success = createSuccess();
-		return predicate(success)
-			? Fail<TSuccess, TFailure>(failure)
-			: Succeed<TSuccess, TFailure>(success);
-	}
+	public static Result<TSuccess, TFailure> Ensure<TAuxiliary, TSuccess, TFailure>(Func<TSuccess> createSuccess, Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
+		=> Ensure(createSuccess(), createAuxiliary, predicate, createFailure);
 
 	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
 	/// <param name="createSuccess">Creates the expected success.</param>
+	/// <param name="auxiliary">The auxiliary to use in combination with <paramref name="predicate" /> and <paramref name="createFailure" />.</param>
 	/// <param name="predicate">Creates a set of criteria.</param>
 	/// <param name="createFailure">Creates the possible failure.</param>
+	/// <typeparam name="TAuxiliary">Type of auxiliary.</typeparam>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
 	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
-	public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(Func<TSuccess> createSuccess, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)
-	{
-		TSuccess success = createSuccess();
-		return predicate(success)
-			? Fail<TSuccess, TFailure>(createFailure(success))
-			: Succeed<TSuccess, TFailure>(success);
-	}
+	public static Result<TSuccess, TFailure> Ensure<TAuxiliary, TSuccess, TFailure>(Func<TSuccess> createSuccess, TAuxiliary auxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
+		=> Ensure(createSuccess(), auxiliary, predicate, createFailure);
 
 	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
 	/// <param name="success">The expected success.</param>
@@ -91,58 +115,6 @@ public static class ResultFactory
 		=> predicate(success, auxiliary)
 			? Fail<TSuccess, TFailure>(createFailure(success, auxiliary))
 			: Succeed<TSuccess, TFailure>(success);
-
-	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
-	/// <param name="success">The expected success.</param>
-	/// <param name="createAuxiliary">Creates the auxiliary to use in combination with <paramref name="predicate" /> and <paramref name="createFailure" />.</param>
-	/// <param name="predicate">Creates a set of criteria.</param>
-	/// <param name="createFailure">Creates the possible failure.</param>
-	/// <typeparam name="TAuxiliary">Type of auxiliary.</typeparam>
-	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
-	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
-	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
-	public static Result<TSuccess, TFailure> Ensure<TAuxiliary, TSuccess, TFailure>(TSuccess success, Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
-	{
-		TAuxiliary auxiliary = createAuxiliary();
-		return predicate(success, auxiliary)
-			? Fail<TSuccess, TFailure>(createFailure(success, auxiliary))
-			: Succeed<TSuccess, TFailure>(success);
-	}
-
-	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
-	/// <param name="createSuccess">Creates the expected success.</param>
-	/// <param name="auxiliary">The auxiliary to use in combination with <paramref name="predicate" /> and <paramref name="createFailure" />.</param>
-	/// <param name="predicate">Creates a set of criteria.</param>
-	/// <param name="createFailure">Creates the possible failure.</param>
-	/// <typeparam name="TAuxiliary">Type of auxiliary.</typeparam>
-	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
-	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
-	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
-	public static Result<TSuccess, TFailure> Ensure<TAuxiliary, TSuccess, TFailure>(Func<TSuccess> createSuccess, TAuxiliary auxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
-	{
-		TSuccess success = createSuccess();
-		return predicate(success, auxiliary)
-			? Fail<TSuccess, TFailure>(createFailure(success, auxiliary))
-			: Succeed<TSuccess, TFailure>(success);
-	}
-
-	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
-	/// <param name="createSuccess">Creates the expected success.</param>
-	/// <param name="createAuxiliary">Creates the auxiliary to use in combination with <paramref name="predicate" /> and <paramref name="createFailure" />.</param>
-	/// <param name="predicate">Creates a set of criteria.</param>
-	/// <param name="createFailure">Creates the possible failure.</param>
-	/// <typeparam name="TAuxiliary">Type of auxiliary.</typeparam>
-	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
-	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
-	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
-	public static Result<TSuccess, TFailure> Ensure<TAuxiliary, TSuccess, TFailure>(Func<TSuccess> createSuccess, Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
-	{
-		TSuccess success = createSuccess();
-		TAuxiliary auxiliary = createAuxiliary();
-		return predicate(success, auxiliary)
-			? Fail<TSuccess, TFailure>(createFailure(success, auxiliary))
-			: Succeed<TSuccess, TFailure>(success);
-	}
 
 	/// <summary>Creates a new successful result.</summary>
 	/// <param name="success">The expected success.</param>

--- a/test/unit/Monads/ResultFactoryTest.cs
+++ b/test/unit/Monads/ResultFactoryTest.cs
@@ -54,42 +54,6 @@ public sealed class ResultFactoryTest
 
 	[Fact]
 	[Trait(root, ensure)]
-	public void Ensure_SuccessPlusTruePredicatePlusFailure_FailedResult()
-	{
-		// Arrange
-		Constellation success = ResultFixture.Success;
-		Func<Constellation, bool> predicate = static _ => true;
-		const string expectedFailure = ResultFixture.Failure;
-
-		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(success, predicate, expectedFailure);
-
-		// Assert
-		ResultAsserter.AreFailed(expectedFailure, actualResult);
-	}
-
-	[Fact]
-	[Trait(root, ensure)]
-	public void Ensure_SuccessPlusFalsePredicatePlusFailure_SuccessfulResult()
-	{
-		// Arrange
-		Constellation expectedSuccess = ResultFixture.Success;
-		Func<Constellation, bool> predicate = static _ => false;
-		const string failure = ResultFixture.Failure;
-
-		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(expectedSuccess, predicate, failure);
-
-		// Assert
-		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
-	}
-
-	#endregion
-
-	#region Overload
-
-	[Fact]
-	[Trait(root, ensure)]
 	public void Ensure_SuccessPlusTruePredicatePlusCreateFailure_FailedResult()
 	{
 		// Arrange
@@ -116,43 +80,6 @@ public sealed class ResultFactoryTest
 
 		// Act
 		Result<Constellation, string> actualResult = ResultFactory.Ensure(expectedSuccess, predicate, createFailure);
-
-		// Assert
-		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
-	}
-
-	#endregion
-
-	#region Overload
-
-	[Fact]
-	[Trait(root, ensure)]
-	public void Ensure_CreateSuccessPlusTruePredicatePlusFailure_FailedResult()
-	{
-		// Arrange
-		Func<Constellation> createSuccess = static () => ResultFixture.Success;
-		Func<Constellation, bool> predicate = static _ => true;
-		const string expectedFailure = ResultFixture.Failure;
-
-		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(createSuccess, predicate, expectedFailure);
-
-		// Assert
-		ResultAsserter.AreFailed(expectedFailure, actualResult);
-	}
-
-	[Fact]
-	[Trait(root, ensure)]
-	public void Ensure_CreateSuccessPlusFalsePredicatePlusFailure_SuccessfulResult()
-	{
-		// Arrange
-		Constellation expectedSuccess = ResultFixture.Success;
-		Func<Constellation> createSuccess = () => expectedSuccess;
-		Func<Constellation, bool> predicate = static _ => false;
-		const string failure = ResultFixture.Failure;
-
-		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(createSuccess, predicate, failure);
 
 		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
@@ -202,17 +129,15 @@ public sealed class ResultFactoryTest
 
 	[Fact]
 	[Trait(root, ensure)]
-	public void Ensure_SuccessPlusAuxiliaryPlusTruePredicatePlusCreateFailure_FailedResult()
+	public void Ensure_CreateSuccessPlusTruePredicatePlusFailure_FailedResult()
 	{
 		// Arrange
-		Constellation success = ResultFixture.Success;
-		const string auxiliary = ResultFixture.Auxiliary;
-		Func<Constellation, string, bool> predicate = static (_, _) => true;
+		Func<Constellation> createSuccess = static () => ResultFixture.Success;
+		Func<Constellation, bool> predicate = static _ => true;
 		const string expectedFailure = ResultFixture.Failure;
-		Func<Constellation, string, string> createFailure = static (_, _) => expectedFailure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(success, auxiliary, predicate, createFailure);
+		Result<Constellation, string> actualResult = ResultFactory.Ensure(createSuccess, predicate, expectedFailure);
 
 		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
@@ -220,16 +145,52 @@ public sealed class ResultFactoryTest
 
 	[Fact]
 	[Trait(root, ensure)]
-	public void Ensure_SuccessPlusAuxiliaryPlusFalsePredicatePlusCreateFailure_SuccessfulResult()
+	public void Ensure_CreateSuccessPlusFalsePredicatePlusFailure_SuccessfulResult()
 	{
 		// Arrange
 		Constellation expectedSuccess = ResultFixture.Success;
-		const string auxiliary = ResultFixture.Auxiliary;
-		Func<Constellation, string, bool> predicate = static (_, _) => false;
-		Func<Constellation, string, string> createFailure = static (_, _) => ResultFixture.Failure;
+		Func<Constellation> createSuccess = () => expectedSuccess;
+		Func<Constellation, bool> predicate = static _ => false;
+		const string failure = ResultFixture.Failure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(expectedSuccess, auxiliary, predicate, createFailure);
+		Result<Constellation, string> actualResult = ResultFactory.Ensure(createSuccess, predicate, failure);
+
+		// Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
+
+	#endregion
+
+	#region Overload
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_SuccessPlusTruePredicatePlusFailure_FailedResult()
+	{
+		// Arrange
+		Constellation success = ResultFixture.Success;
+		Func<Constellation, bool> predicate = static _ => true;
+		const string expectedFailure = ResultFixture.Failure;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultFactory.Ensure(success, predicate, expectedFailure);
+
+		// Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_SuccessPlusFalsePredicatePlusFailure_SuccessfulResult()
+	{
+		// Arrange
+		Constellation expectedSuccess = ResultFixture.Success;
+		Func<Constellation, bool> predicate = static _ => false;
+		const string failure = ResultFixture.Failure;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultFactory.Ensure(expectedSuccess, predicate, failure);
 
 		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
@@ -269,6 +230,46 @@ public sealed class ResultFactoryTest
 
 		// Act
 		Result<Constellation, string> actualResult = ResultFactory.Ensure(expectedSuccess, createAuxiliary, predicate, createFailure);
+
+		// Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
+
+	#endregion
+
+	#region Overload
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_CreateSuccessPlusCreateAuxiliaryPlusTruePredicatePlusCreateFailure_FailedResult()
+	{
+		// Arrange
+		Func<Constellation> createSuccess = static () => ResultFixture.Success;
+		Func<string> createAuxiliary = static () => ResultFixture.Auxiliary;
+		Func<Constellation, string, bool> predicate = static (_, _) => true;
+		const string expectedFailure = ResultFixture.Failure;
+		Func<Constellation, string, string> createFailure = static (_, _) => expectedFailure;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultFactory.Ensure(createSuccess, createAuxiliary, predicate, createFailure);
+
+		// Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_CreateSuccessPlusCreateAuxiliaryPlusFalsePredicatePlusCreateFailure_SuccessfulResult()
+	{
+		// Arrange
+		Constellation expectedSuccess = ResultFixture.Success;
+		Func<Constellation> createSuccess = () => expectedSuccess;
+		Func<string> createAuxiliary = static () => ResultFixture.Auxiliary;
+		Func<Constellation, string, bool> predicate = static (_, _) => false;
+		Func<Constellation, string, string> createFailure = static (_, _) => ResultFixture.Failure;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultFactory.Ensure(createSuccess, createAuxiliary, predicate, createFailure);
 
 		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
@@ -320,17 +321,17 @@ public sealed class ResultFactoryTest
 
 	[Fact]
 	[Trait(root, ensure)]
-	public void Ensure_CreateSuccessPlusCreateAuxiliaryPlusTruePredicatePlusCreateFailure_FailedResult()
+	public void Ensure_SuccessPlusAuxiliaryPlusTruePredicatePlusCreateFailure_FailedResult()
 	{
 		// Arrange
-		Func<Constellation> createSuccess = static () => ResultFixture.Success;
-		Func<string> createAuxiliary = static () => ResultFixture.Auxiliary;
+		Constellation success = ResultFixture.Success;
+		const string auxiliary = ResultFixture.Auxiliary;
 		Func<Constellation, string, bool> predicate = static (_, _) => true;
 		const string expectedFailure = ResultFixture.Failure;
 		Func<Constellation, string, string> createFailure = static (_, _) => expectedFailure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(createSuccess, createAuxiliary, predicate, createFailure);
+		Result<Constellation, string> actualResult = ResultFactory.Ensure(success, auxiliary, predicate, createFailure);
 
 		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
@@ -338,17 +339,16 @@ public sealed class ResultFactoryTest
 
 	[Fact]
 	[Trait(root, ensure)]
-	public void Ensure_CreateSuccessPlusCreateAuxiliaryPlusFalsePredicatePlusCreateFailure_SuccessfulResult()
+	public void Ensure_SuccessPlusAuxiliaryPlusFalsePredicatePlusCreateFailure_SuccessfulResult()
 	{
 		// Arrange
 		Constellation expectedSuccess = ResultFixture.Success;
-		Func<Constellation> createSuccess = () => expectedSuccess;
-		Func<string> createAuxiliary = static () => ResultFixture.Auxiliary;
+		const string auxiliary = ResultFixture.Auxiliary;
 		Func<Constellation, string, bool> predicate = static (_, _) => false;
 		Func<Constellation, string, string> createFailure = static (_, _) => ResultFixture.Failure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(createSuccess, createAuxiliary, predicate, createFailure);
+		Result<Constellation, string> actualResult = ResultFactory.Ensure(expectedSuccess, auxiliary, predicate, createFailure);
 
 		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -100,60 +100,6 @@ public sealed class ResultTest
 
 	[Fact]
 	[Trait(root, ensure)]
-	public void Ensure_FailedResultPlusTruePredicatePlusFailure_FailedResult()
-	{
-		// Arrange
-		const string expectedFailure = ResultFixture.Failure;
-		Func<Constellation, bool> predicate = static _ => true;
-		string failure = ResultFixture.RandomFailure;
-
-		// Act
-		Result<Constellation, string> actualResult = ResultMother.Fail(expectedFailure)
-			.Ensure(predicate, failure);
-
-		// Assert
-		ResultAsserter.AreFailed(expectedFailure, actualResult);
-	}
-
-	[Fact]
-	[Trait(root, ensure)]
-	public void Ensure_SuccessfulResultPlusTruePredicatePlusFailure_FailedResult()
-	{
-		// Arrange
-		Func<Constellation, bool> predicate = static _ => true;
-		const string expectedFailure = ResultFixture.Failure;
-
-		// Act
-		Result<Constellation, string> actualResult = ResultMother.Succeed()
-			.Ensure(predicate, expectedFailure);
-
-		// Assert
-		ResultAsserter.AreFailed(expectedFailure, actualResult);
-	}
-
-	[Fact]
-	[Trait(root, ensure)]
-	public void Ensure_SuccessfulResultPlusFalsePredicatePlusFailure_SuccessfulResult()
-	{
-		// Arrange
-		Constellation expectedSuccess = ResultFixture.Success;
-		Func<Constellation, bool> predicate = static _ => false;
-		const string failure = ResultFixture.Failure;
-
-		// Act
-		Result<Constellation, string> actualResult = ResultMother.Succeed(expectedSuccess)
-			.Ensure(predicate, failure);
-
-		// Assert
-		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
-	}
-
-	#endregion
-
-	#region Overload
-
-	[Fact]
-	[Trait(root, ensure)]
 	public void Ensure_FailedResultPlusTruePredicatePlusCreateFailure_FailedResult()
 	{
 		// Arrange
@@ -209,17 +155,16 @@ public sealed class ResultTest
 
 	[Fact]
 	[Trait(root, ensure)]
-	public void Ensure_FailedResultPlusAuxiliaryPlusTruePredicatePlusCreateFailure_FailedResult()
+	public void Ensure_FailedResultPlusTruePredicatePlusFailure_FailedResult()
 	{
 		// Arrange
 		const string expectedFailure = ResultFixture.Failure;
-		const string auxiliary = ResultFixture.Auxiliary;
-		Func<Constellation, string, bool> predicate = static (_, _) => true;
-		Func<Constellation, string, string> createFailure = static (_, _) => ResultFixture.RandomFailure;
+		Func<Constellation, bool> predicate = static _ => true;
+		string failure = ResultFixture.RandomFailure;
 
 		// Act
 		Result<Constellation, string> actualResult = ResultMother.Fail(expectedFailure)
-			.Ensure(auxiliary, predicate, createFailure);
+			.Ensure(predicate, failure);
 
 		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
@@ -227,17 +172,15 @@ public sealed class ResultTest
 
 	[Fact]
 	[Trait(root, ensure)]
-	public void Ensure_SuccessfulResultPlusAuxiliaryPlusTruePredicatePlusCreateFailure_FailedResult()
+	public void Ensure_SuccessfulResultPlusTruePredicatePlusFailure_FailedResult()
 	{
 		// Arrange
-		const string auxiliary = ResultFixture.Auxiliary;
-		Func<Constellation, string, bool> predicate = static (_, _) => true;
+		Func<Constellation, bool> predicate = static _ => true;
 		const string expectedFailure = ResultFixture.Failure;
-		Func<Constellation, string, string> createFailure = static (_, _) => expectedFailure;
 
 		// Act
 		Result<Constellation, string> actualResult = ResultMother.Succeed()
-			.Ensure(auxiliary, predicate, createFailure);
+			.Ensure(predicate, expectedFailure);
 
 		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
@@ -245,17 +188,16 @@ public sealed class ResultTest
 
 	[Fact]
 	[Trait(root, ensure)]
-	public void Ensure_SuccessfulResultPlusAuxiliaryPlusFalsePredicatePlusCreateFailure_SuccessfulResult()
+	public void Ensure_SuccessfulResultPlusFalsePredicatePlusFailure_SuccessfulResult()
 	{
 		// Arrange
 		Constellation expectedSuccess = ResultFixture.Success;
-		const string auxiliary = ResultFixture.Auxiliary;
-		Func<Constellation, string, bool> predicate = static (_, _) => false;
-		Func<Constellation, string, string> createFailure = static (_, _) => ResultFixture.Failure;
+		Func<Constellation, bool> predicate = static _ => false;
+		const string failure = ResultFixture.Failure;
 
 		// Act
 		Result<Constellation, string> actualResult = ResultMother.Succeed(expectedSuccess)
-			.Ensure(auxiliary, predicate, createFailure);
+			.Ensure(predicate, failure);
 
 		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
@@ -321,44 +263,67 @@ public sealed class ResultTest
 
 	#endregion
 
-	#endregion
-
-	#region Map
-
 	#region Overload
 
 	[Fact]
-	[Trait(root, map)]
-	public void Map_FailedResultPlusSuccessToMap_FailedResult()
+	[Trait(root, ensure)]
+	public void Ensure_FailedResultPlusAuxiliaryPlusTruePredicatePlusCreateFailure_FailedResult()
 	{
 		// Arrange
 		const string expectedFailure = ResultFixture.Failure;
-		Start successToMap = ResultFixture.SuccessToMap;
+		const string auxiliary = ResultFixture.Auxiliary;
+		Func<Constellation, string, bool> predicate = static (_, _) => true;
+		Func<Constellation, string, string> createFailure = static (_, _) => ResultFixture.RandomFailure;
 
 		// Act
-		Result<Start, string> actualResult = ResultMother.Fail(expectedFailure)
-			.Map(successToMap);
+		Result<Constellation, string> actualResult = ResultMother.Fail(expectedFailure)
+			.Ensure(auxiliary, predicate, createFailure);
 
 		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
 
 	[Fact]
-	[Trait(root, map)]
-	public void Map_SuccessfulResultPlusSuccessToMap_SuccessfulResult()
+	[Trait(root, ensure)]
+	public void Ensure_SuccessfulResultPlusAuxiliaryPlusTruePredicatePlusCreateFailure_FailedResult()
 	{
 		// Arrange
-		Start expectedSuccess = ResultFixture.SuccessToMap;
+		const string auxiliary = ResultFixture.Auxiliary;
+		Func<Constellation, string, bool> predicate = static (_, _) => true;
+		const string expectedFailure = ResultFixture.Failure;
+		Func<Constellation, string, string> createFailure = static (_, _) => expectedFailure;
 
 		// Act
-		Result<Start, string> actualResult = ResultMother.Succeed()
-			.Map(expectedSuccess);
+		Result<Constellation, string> actualResult = ResultMother.Succeed()
+			.Ensure(auxiliary, predicate, createFailure);
+
+		// Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, ensure)]
+	public void Ensure_SuccessfulResultPlusAuxiliaryPlusFalsePredicatePlusCreateFailure_SuccessfulResult()
+	{
+		// Arrange
+		Constellation expectedSuccess = ResultFixture.Success;
+		const string auxiliary = ResultFixture.Auxiliary;
+		Func<Constellation, string, bool> predicate = static (_, _) => false;
+		Func<Constellation, string, string> createFailure = static (_, _) => ResultFixture.Failure;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultMother.Succeed(expectedSuccess)
+			.Ensure(auxiliary, predicate, createFailure);
 
 		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
 	}
 
 	#endregion
+
+	#endregion
+
+	#region Map
 
 	#region Overload
 
@@ -389,6 +354,41 @@ public sealed class ResultTest
 		// Act
 		Result<Start, string> actualResult = ResultMother.Succeed()
 			.Map(createSuccessToMap);
+
+		// Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
+
+	#endregion
+
+	#region Overload
+
+	[Fact]
+	[Trait(root, map)]
+	public void Map_FailedResultPlusSuccessToMap_FailedResult()
+	{
+		// Arrange
+		const string expectedFailure = ResultFixture.Failure;
+		Start successToMap = ResultFixture.SuccessToMap;
+
+		// Act
+		Result<Start, string> actualResult = ResultMother.Fail(expectedFailure)
+			.Map(successToMap);
+
+		// Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	[Fact]
+	[Trait(root, map)]
+	public void Map_SuccessfulResultPlusSuccessToMap_SuccessfulResult()
+	{
+		// Arrange
+		Start expectedSuccess = ResultFixture.SuccessToMap;
+
+		// Act
+		Result<Start, string> actualResult = ResultMother.Succeed()
+			.Map(expectedSuccess);
 
 		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Description <!-- Required -->

The purpose of this change is to share the behavior between overloads instead of generating redundant or repetitive implementations.

<!-- ## Evidence <!-- Optional -->
