### PR TITLE
feature(`Result`): add `Reduce` method

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -118,5 +118,15 @@ public sealed class Result<TSuccess, TFailure>
 		=> IsFailed
 			? new(Failure)
 			: createResultToBind(Success);
+
+	/// <summary>Creates a new reduced failure if the result is failed; otherwise, creates a new reduced success.</summary>
+	/// <param name="createReducedSuccess">Creates the expected reduced success.</param>
+	/// <param name="createReducedFailure">Creates the possible reduced failure.</param>
+	/// <typeparam name="TReducer">Type of reducer.</typeparam>
+	/// <returns>A new reduced failure if the result is failed; otherwise, a new reduced success.</returns>
+	public TReducer Reduce<TReducer>(Func<TSuccess, TReducer> createReducedSuccess, Func<TFailure, TReducer> createReducedFailure)
+		=> IsFailed
+			? createReducedFailure(Failure)
+			: createReducedSuccess(Success);
 }
 #pragma warning restore CA1062

--- a/source/Monads/ResultFactory.cs
+++ b/source/Monads/ResultFactory.cs
@@ -6,7 +6,7 @@ public static class ResultFactory
 {
 	/// <summary>Creates a new failed result if the value of <paramref name="createSuccess" /> throws <typeparamref name="TException" />; otherwise, creates a new successful result.</summary>
 	/// <param name="createSuccess">Creates the expected success.</param>
-	/// <param name="createFailure">Creates the possible failure in combination with <typeparamref name="TException" />.</param>
+	/// <param name="createFailure">Creates the possible failure.</param>
 	/// <typeparam name="TException">Type of possible exception.</typeparam>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
@@ -24,49 +24,49 @@ public static class ResultFactory
 		}
 	}
 
-	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
+	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, creates a new successful result.</summary>
 	/// <param name="success">The expected success.</param>
 	/// <param name="predicate">Creates a set of criteria.</param>
 	/// <param name="createFailure">Creates the possible failure.</param>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
-	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
+	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, a new successful result.</returns>
 	public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(TSuccess success, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)
 		=> Ensure(success, predicate, createFailure(success));
 
-	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
+	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, creates a new successful result.</summary>
 	/// <param name="createSuccess">Creates the expected success.</param>
 	/// <param name="predicate">Creates a set of criteria.</param>
 	/// <param name="createFailure">Creates the possible failure.</param>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
-	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
+	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, a new successful result.</returns>
 	public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(Func<TSuccess> createSuccess, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)
 		=> Ensure(createSuccess(), predicate, createFailure);
 
-	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
+	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, creates a new successful result.</summary>
 	/// <param name="createSuccess">Creates the expected success.</param>
 	/// <param name="predicate">Creates a set of criteria.</param>
 	/// <param name="failure">The possible failure.</param>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
-	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
+	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, a new successful result.</returns>
 	public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(Func<TSuccess> createSuccess, Func<TSuccess, bool> predicate, TFailure failure)
 		=> Ensure(createSuccess(), predicate, failure);
 
-	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
+	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, creates a new successful result.</summary>
 	/// <param name="success">The expected success.</param>
 	/// <param name="predicate">Creates a set of criteria.</param>
 	/// <param name="failure">The possible failure.</param>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
-	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
+	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, a new successful result.</returns>
 	public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(TSuccess success, Func<TSuccess, bool> predicate, TFailure failure)
 		=> predicate(success)
 			? Fail<TSuccess, TFailure>(failure)
 			: Succeed<TSuccess, TFailure>(success);
 
-	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
+	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, creates a new successful result.</summary>
 	/// <param name="success">The expected success.</param>
 	/// <param name="createAuxiliary">Creates the auxiliary to use in combination with <paramref name="predicate" /> and <paramref name="createFailure" />.</param>
 	/// <param name="predicate">Creates a set of criteria.</param>
@@ -74,11 +74,11 @@ public static class ResultFactory
 	/// <typeparam name="TAuxiliary">Type of auxiliary.</typeparam>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
-	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
+	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, a new successful result.</returns>
 	public static Result<TSuccess, TFailure> Ensure<TAuxiliary, TSuccess, TFailure>(TSuccess success, Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
 		=> Ensure(success, createAuxiliary(), predicate, createFailure);
 
-	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
+	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, creates a new successful result.</summary>
 	/// <param name="createSuccess">Creates the expected success.</param>
 	/// <param name="createAuxiliary">Creates the auxiliary to use in combination with <paramref name="predicate" /> and <paramref name="createFailure" />.</param>
 	/// <param name="predicate">Creates a set of criteria.</param>
@@ -86,11 +86,11 @@ public static class ResultFactory
 	/// <typeparam name="TAuxiliary">Type of auxiliary.</typeparam>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
-	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
+	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, a new successful result.</returns>
 	public static Result<TSuccess, TFailure> Ensure<TAuxiliary, TSuccess, TFailure>(Func<TSuccess> createSuccess, Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
 		=> Ensure(createSuccess(), createAuxiliary, predicate, createFailure);
 
-	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
+	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, creates a new successful result.</summary>
 	/// <param name="createSuccess">Creates the expected success.</param>
 	/// <param name="auxiliary">The auxiliary to use in combination with <paramref name="predicate" /> and <paramref name="createFailure" />.</param>
 	/// <param name="predicate">Creates a set of criteria.</param>
@@ -98,11 +98,11 @@ public static class ResultFactory
 	/// <typeparam name="TAuxiliary">Type of auxiliary.</typeparam>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
-	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
+	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, a new successful result.</returns>
 	public static Result<TSuccess, TFailure> Ensure<TAuxiliary, TSuccess, TFailure>(Func<TSuccess> createSuccess, TAuxiliary auxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
 		=> Ensure(createSuccess(), auxiliary, predicate, createFailure);
 
-	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
+	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, creates a new successful result.</summary>
 	/// <param name="success">The expected success.</param>
 	/// <param name="auxiliary">The auxiliary to use in combination with <paramref name="predicate" /> and <paramref name="createFailure" />.</param>
 	/// <param name="predicate">Creates a set of criteria.</param>
@@ -110,7 +110,7 @@ public static class ResultFactory
 	/// <typeparam name="TAuxiliary">Type of auxiliary.</typeparam>
 	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
-	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
+	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, a new successful result.</returns>
 	public static Result<TSuccess, TFailure> Ensure<TAuxiliary, TSuccess, TFailure>(TSuccess success, TAuxiliary auxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
 		=> predicate(success, auxiliary)
 			? Fail<TSuccess, TFailure>(createFailure(success, auxiliary))

--- a/test/unit/Monads/Mothers/ResultMother.cs
+++ b/test/unit/Monads/Mothers/ResultMother.cs
@@ -11,6 +11,9 @@ internal static class ResultMother
 	internal static Result<Constellation, string> SucceedRandomly()
 		=> new(ResultFixture.RandomSuccess);
 
+	internal static Result<Constellation, string> Fail()
+		=> new(ResultFixture.Failure);
+
 	internal static Result<Constellation, string> Fail(string failure)
 		=> new(failure);
 }

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -14,6 +14,8 @@ public sealed class ResultTest
 
 	private const string bind = nameof(Result<object, object>.Bind);
 
+	private const string reduce = nameof(Result<object, object>.Reduce);
+
 	#region Constructor
 
 	#region Overload
@@ -446,6 +448,44 @@ public sealed class ResultTest
 
 		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
+
+	#endregion
+
+	#region Reduce
+
+	[Fact]
+	[Trait(root, reduce)]
+	public void Reduce_FailedResultPlusCreateReducedSuccessPlusCreateReducedFailure_ReducedFailure()
+	{
+		// Arrange
+		object expectedReduction = ResultFixture.Failure;
+		Func<Constellation, object> createReducedSuccess = static _ => ResultFixture.Success;
+		Func<string, object> createReducedFailure = _ => expectedReduction;
+
+		// Act
+		object actualReduction = ResultMother.Fail()
+			.Reduce(createReducedSuccess, createReducedFailure);
+
+		// Assert
+		Assert.Equal(expectedReduction, actualReduction);
+	}
+
+	[Fact]
+	[Trait(root, reduce)]
+	public void Reduce_SuccessfulResultPlusCreateReducedSuccessPlusCreateReducedFailure_ReducedSuccess()
+	{
+		// Arrange
+		Constellation expectedReduction = ResultFixture.Success;
+		Func<Constellation, object> createReducedSuccess = _ => expectedReduction;
+		Func<string, object> createReducedFailure = static _ => ResultFixture.Failure;
+
+		// Act
+		object actualReduction = ResultMother.Succeed()
+			.Reduce(createReducedSuccess, createReducedFailure);
+
+		// Assert
+		Assert.Equal(expectedReduction, actualReduction);
 	}
 
 	#endregion


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Description <!-- Required -->

The purpose of this change is to extend [Result<TSuccess, TFailure>](source/Monads/Result.cs). The details of this new feature are:

- **Type**: [Result<TSuccess, TFailure>](source/Monads/Result.cs).
- **Signature**:

  ```cs
    public TReducer Reduce<TReducer>(Func<TSuccess, TReducer> createReducedSuccess, Func<TFailure, TReducer> createReducedFailure)
  ```

- **Member**: Method.
- **Description**: Creates a new reduced failure if the result is failed; otherwise, creates a new reduced success.
- **Parameters**:
  - `createReducedSuccess`: Creates the expected reduced success.
  - `createReducedFailure`: Creates the possible reduced failure.
- **Generics**:
  - `TReducer`: Type of reducer.

<!-- ## Evidence <!-- Optional -->
