### PR TITLE
chore: enable `first-line-heading` rule

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,5 @@
 {
-	"first-line-heading": false,
+	"first-line-heading": true,
 	"heading-style": false,
 	"hr-style": {
 		"style": "---"


### PR DESCRIPTION
<!-- ## Ticket(s) <!-- Optional -->

## Description <!-- Required -->

The purpose of this change is to require the use of a [top-level heading](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md041---first-line-in-a-file-should-be-a-top-level-heading) on the first line to provide more specific context about the file and its contents.

<!-- ## Evidence <!-- Optional -->
