### PR TITLE
chore: limit dependencies section exclusively to the `NuGet` package manager

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -14,4 +14,8 @@ changelog:
         - "topic: feature"
     - title: "Dependencies management"
       labels:
-        - "topic: dependency"
+        - "package manager: nuget"
+      exclude:
+        labels:
+          - "package manager: github actions"
+          - "package manager: pnpm"


### PR DESCRIPTION
# Integration

***Thank you very much for your contribution.***

Please read and follow our [code of conduct](../code-of-conduct.md) and [contribution guidelines](../contributing.md).

## Table of contents

1. [Tickets](#tickets)
2. [Description](#description)
3. [Additional information](#additional-information)

### Tickets

<!-- Provide related issue tickets | Optional -->

Undefined

***[Top](#integration)***

### Description

<!-- Provide a concise and clear description | Required -->

The purpose of this change is to limit the dependencies section exclusively to the [NuGet package manager](https://www.nuget.org) when new release notes are released.

***[Top](#integration)***

### Additional information

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

Undefined

***[Top](#integration)***
