### PR TITLE
feature(`Result`): add `DoOnSuccess` method

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -94,6 +94,19 @@ public sealed class Result<TSuccess, TFailure>
 			: this;
 	}
 
+	/// <summary>Executes an action if the previous result is successful.</summary>
+	/// <param name="execute">The action to execute.</param>
+	/// <returns>The previous result.</returns>
+	public Result<TSuccess, TFailure> DoOnSuccess(Action<TSuccess> execute)
+	{
+		if (IsFailed)
+		{
+			return this;
+		}
+		execute(Success);
+		return this;
+	}
+
 	/// <summary>Creates a new result with the same or different type of expected success.</summary>
 	/// <param name="createSuccessToMap">Creates the expected success to map.</param>
 	/// <typeparam name="TSuccessToMap">Type of expected success to map.</typeparam>
@@ -119,11 +132,11 @@ public sealed class Result<TSuccess, TFailure>
 			? new(Failure)
 			: createResultToBind(Success);
 
-	/// <summary>Creates a new reduced failure if the result is failed; otherwise, creates a new reduced success.</summary>
+	/// <summary>Creates a new reduced failure if the previous result is failed; otherwise, creates a new reduced success.</summary>
 	/// <param name="createReducedSuccess">Creates the expected reduced success.</param>
 	/// <param name="createReducedFailure">Creates the possible reduced failure.</param>
 	/// <typeparam name="TReducer">Type of reducer.</typeparam>
-	/// <returns>A new reduced failure if the result is failed; otherwise, a new reduced success.</returns>
+	/// <returns>A new reduced failure if the previous result is failed; otherwise, a new reduced success.</returns>
 	public TReducer Reduce<TReducer>(Func<TSuccess, TReducer> createReducedSuccess, Func<TFailure, TReducer> createReducedFailure)
 		=> IsFailed
 			? createReducedFailure(Failure)

--- a/source/Sagitta.Core.csproj
+++ b/source/Sagitta.Core.csproj
@@ -7,10 +7,10 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Maintainer>David Andrés Hernández Triana</Maintainer>
 		<Authors>$(Maintainer)</Authors>
-		<Description>Functional paradigm abstractions | Core</Description>
+		<Description>Functional paradigm abstractions - Core</Description>
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
-		<PackageTags>$(Company); Sagitta; Functional; Paradigm; Result</PackageTags>
+		<PackageTags>$(Company); Sagitta; Functional; Paradigm; Result; ResultFactory</PackageTags>
 		<NeutralLanguage>en-US</NeutralLanguage>
 		<RepositoryType>git</RepositoryType>
 		<RepositoryUrl>https://github.com/daht-x/sagitta-core</RepositoryUrl>

--- a/test/unit/Monads/Asserters/ResultAsserter.cs
+++ b/test/unit/Monads/Asserters/ResultAsserter.cs
@@ -4,17 +4,27 @@ internal static class ResultAsserter
 {
 	internal static void AreSuccessful<TSuccess, TFailure>(TSuccess expectedSuccess, Result<TSuccess, TFailure> actualResult)
 	{
-		Assert.True(actualResult.IsSuccessful);
+		IsSuccessful(actualResult);
 		Assert.Equal(expectedSuccess, actualResult.Success);
-		Assert.False(actualResult.IsFailed);
 		Assert.Equal(default, actualResult.Failure);
+	}
+
+	internal static void IsSuccessful<TSuccess, TFailure>(Result<TSuccess, TFailure> actualResult)
+	{
+		Assert.True(actualResult.IsSuccessful);
+		Assert.False(actualResult.IsFailed);
 	}
 
 	internal static void AreFailed<TSuccess, TFailure>(TFailure expectedFailure, Result<TSuccess, TFailure> actualResult)
 	{
-		Assert.False(actualResult.IsSuccessful);
+		IsFailed(actualResult);
 		Assert.Equal(default, actualResult.Success);
-		Assert.True(actualResult.IsFailed);
 		Assert.Equal(expectedFailure, actualResult.Failure);
+	}
+
+	internal static void IsFailed<TSuccess, TFailure>(Result<TSuccess, TFailure> actualResult)
+	{
+		Assert.False(actualResult.IsSuccessful);
+		Assert.True(actualResult.IsFailed);
 	}
 }

--- a/test/unit/Monads/ResultFactoryTest.cs
+++ b/test/unit/Monads/ResultFactoryTest.cs
@@ -198,7 +198,7 @@ public sealed class ResultFactoryTest
 
 	#endregion
 
-	#region Overlaod
+	#region Overload
 
 	[Fact]
 	[Trait(root, ensure)]

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -10,6 +10,8 @@ public sealed class ResultTest
 
 	private const string ensure = nameof(Result<object, object>.Ensure);
 
+	private const string doOnSuccess = nameof(Result<object, object>.DoOnSuccess);
+
 	private const string map = nameof(Result<object, object>.Map);
 
 	private const string bind = nameof(Result<object, object>.Bind);
@@ -322,6 +324,44 @@ public sealed class ResultTest
 	}
 
 	#endregion
+
+	#endregion
+
+	#region DoOnSuccess
+
+	[Fact]
+	[Trait(root, doOnSuccess)]
+	public void DoOnSuccess_FailedResultPlusExecute_FailedResult()
+	{
+		// Arrange
+		bool status = false;
+		Action<Constellation> execute = _ => status = true;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultMother.Fail()
+			.DoOnSuccess(execute);
+
+		// Assert
+		Assert.False(status);
+		ResultAsserter.IsFailed(actualResult);
+	}
+
+	[Fact]
+	[Trait(root, doOnSuccess)]
+	public void DoOnSuccess_SuccessfulResultPlusExecute_SuccessfulResult()
+	{
+		// Arrange
+		bool status = false;
+		Action<Constellation> execute = _ => status = true;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultMother.Succeed()
+			.DoOnSuccess(execute);
+
+		// Assert
+		Assert.True(status);
+		ResultAsserter.IsSuccessful(actualResult);
+	}
 
 	#endregion
 


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](../code-of-conduct.md) and [contributing guidelines](../contributing.md).

## Table of contents

1. [Tickets](#tickets)
2. [Description](#description)
3. [Additional information](#additional-information)

### Tickets

<!-- Provide related issue tickets | Optional -->

Undefined.

***[Top](#pull-request)***

### Description

<!-- Provide a concise and clear description | Required -->

The [Result<Success, Failure>](https://github.com/daht-x/sagitta-core/blob/main/documentation/monads/result.md) type has been extended. The details of this new member are:

- **Type**: Method.
- **Declaration**:

  ```cs
  public Result<TSuccess, TFailure> DoOnSuccess(Action<TSuccess> execute)
  ```

- **Description**:

  Executes an action if the previous result is successful.

  | Parameter | Description           |
  |:----------|:----------------------|
  | `execute` | The action to execute |

  Returns the previous result.

***[Top](#pull-request)***

### Additional information

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

Undefined.

***[Top](#pull-request)***
