### PR TITLE
feature(`Result`): add `DoOnFailure` method

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -107,6 +107,19 @@ public sealed class Result<TSuccess, TFailure>
 		return this;
 	}
 
+	/// <summary>Executes an action if the previous result is failed.</summary>
+	/// <param name="execute">The action to execute.</param>
+	/// <returns>The previous result.</returns>
+	public Result<TSuccess, TFailure> DoOnFailure(Action<TFailure> execute)
+	{
+		if (IsSuccessful)
+		{
+			return this;
+		}
+		execute(Failure);
+		return this;
+	}
+
 	/// <summary>Creates a new result with the same or different type of expected success.</summary>
 	/// <param name="createSuccessToMap">Creates the expected success to map.</param>
 	/// <typeparam name="TSuccessToMap">Type of expected success to map.</typeparam>

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -12,6 +12,8 @@ public sealed class ResultTest
 
 	private const string doOnSuccess = nameof(Result<object, object>.DoOnSuccess);
 
+	private const string doOnFailure = nameof(Result<object, object>.DoOnFailure);
+
 	private const string map = nameof(Result<object, object>.Map);
 
 	private const string bind = nameof(Result<object, object>.Bind);
@@ -361,6 +363,44 @@ public sealed class ResultTest
 		// Assert
 		Assert.True(status);
 		ResultAsserter.IsSuccessful(actualResult);
+	}
+
+	#endregion
+
+	#region DoOnFailure
+
+	[Fact]
+	[Trait(root, doOnFailure)]
+	public void DoOnFailure_SuccessfulResultPlusExecute_SuccessfulResult()
+	{
+		// Arrange
+		bool status = false;
+		Action<string> execute = _ => status = true;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultMother.Succeed()
+			.DoOnFailure(execute);
+
+		// Assert
+		Assert.False(status);
+		ResultAsserter.IsSuccessful(actualResult);
+	}
+
+	[Fact]
+	[Trait(root, doOnFailure)]
+	public void DoOnFailure_FailedResultPlusExecute_FailedResult()
+	{
+		// Arrange
+		bool status = false;
+		Action<string> execute = _ => status = true;
+
+		// Act
+		Result<Constellation, string> actualResult = ResultMother.Fail()
+			.DoOnFailure(execute);
+
+		// Assert
+		Assert.True(status);
+		ResultAsserter.IsFailed(actualResult);
 	}
 
 	#endregion


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](../code-of-conduct.md) and [contributing guidelines](../contributing.md).

## Table of contents

1. [Tickets](#tickets)
2. [Description](#description)
3. [Additional information](#additional-information)

### Tickets

<!-- Provide related issue tickets | Optional -->

Undefined.

***[Top](#pull-request)***

### Description

<!-- Provide a concise and clear description | Required -->

The [Result<Success, Failure>](https://github.com/daht-x/sagitta-core/blob/main/documentation/monads/result.md) type has been extended. The details of this new member are:

- **Type**: Method.
- **Declaration**:

  ```cs
  public Result<TSuccess, TFailure> DoOnFailure(Action<TFailure> execute)
  ```

- **Description**:

  Executes an action if the previous result is failed.

  | Parameter | Description           |
  |:----------|:----------------------|
  | `execute` | The action to execute |

  Returns the previous result.

***[Top](#pull-request)***

### Additional information

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

Undefined.

***[Top](#pull-request)***
