### PR TITLE
chore: remove `install` command for `husky` preparation

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	},
 	"private": true,
 	"scripts": {
-		"prepare": "husky install"
+		"prepare": "husky"
 	},
 	"type": "module"
 }


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta-core/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta-core/blob/main/contributing.md).

## Table of contents

1. [Tickets](#tickets)
2. [Description](#description)
3. [Additional information](#additional-information)

### Tickets

<!-- Provide related issue tickets | Optional -->

Undefined.

***[Top](#pull-request)***

### Description

<!-- Provide a concise and clear description | Required -->

The install command in `Husky` has been deprecated as of version [9.x.x](https://github.com/typicode/husky/releases/tag/v9.0.1).

Undefined.

***[Top](#pull-request)***

### Additional information

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

Undefined.

***[Top](#pull-request)***
