### PR TITLE
chore: add latest available `commitlint` rules

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -137,6 +137,7 @@ const rootConfiguration = {
 			ruleSeverity.error,
 			ruleCompliance.always,
 			[
+				"compatibility",
 				"feature",
 				"test",
 				"build",

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -3,7 +3,7 @@ import { ruleCompliance, ruleSeverity } from "./linter-configuration.js";
 const namingStyle = {
 	lowerCase: "lower-case"
 };
-const defaultMaximumLength = 100;
+const defaultMaximumLength = 120;
 const defaultMaximumLineLength = 400;
 const defaultMinimumLength = 0;
 const rootConfiguration = {

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -59,6 +59,10 @@ const rootConfiguration = {
 			ruleCompliance.always,
 			defaultMinimumLength
 		],
+		"header-trim": [
+			ruleSeverity.error,
+			ruleCompliance.always
+		],
 		"header-case": [
 			ruleSeverity.warning,
 			ruleCompliance.always,


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta-core/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta-core/blob/main/contributing.md).

## Table of contents

1. [Tickets](#tickets)
2. [Description](#description)
3. [Additional information](#additional-information)

### Tickets

<!-- Provide related issue tickets | Optional -->

Undefined.

***[Top](#pull-request)***

### Description

<!-- Provide a concise and clear description | Required -->

- The default maximum length was increased from 100 to 120.
- The [`header-trim`](https://commitlint.js.org/#/reference-rules?id=header-trim) rule was added to ensure that the commit header only contains content, without any leading or trailing whitespace.
- The `compatibility` enumeration was added to determine a process or action that affects the compatibility.

***[Top](#pull-request)***

### Additional information

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

Undefined.

***[Top](#pull-request)***
