### PR TITLE
compatibility(`Result`): invert generics position from  `<TFailure, TSuccess>` to `<TSuccess, TFailure>`

### DIFF
--- a/source/Monads/ResultFactory.cs
+++ b/source/Monads/ResultFactory.cs
@@ -1,26 +1,26 @@
 namespace Daht.Sagitta.Core.Monads;
 
 #pragma warning disable CA1062
-/// <summary>Type that exposes a set of ways to initialize <see cref="Result{TFailure, TSuccess}" />.</summary>
+/// <summary>Type intended to expose a set of ways to initialize <see cref="Result{TFailure,TSuccess}" />.</summary>
 public static class ResultFactory
 {
 	/// <summary>Creates a new failed result if the value of <paramref name="createSuccess" /> throws <typeparamref name="TException" />; otherwise, creates a new successful result.</summary>
 	/// <param name="createSuccess">Creates the expected success.</param>
 	/// <param name="createFailure">Creates the possible failure.</param>
 	/// <typeparam name="TException">Type of possible exception.</typeparam>
-	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <returns>A new failed result if the value of <paramref name="createSuccess" /> throws <typeparamref name="TException" />; otherwise, a new successful result.</returns>
-	public static Result<TSuccess, TFailure> Catch<TException, TSuccess, TFailure>(Func<TSuccess> createSuccess, Func<TException, TFailure> createFailure)
+	public static Result<TFailure, TSuccess> Catch<TException, TFailure, TSuccess>(Func<TSuccess> createSuccess, Func<TException, TFailure> createFailure)
 		where TException : Exception
 	{
 		try
 		{
-			return Succeed<TSuccess, TFailure>(createSuccess);
+			return Succeed<TFailure, TSuccess>(createSuccess);
 		}
 		catch (TException exception)
 		{
-			return Fail<TSuccess, TFailure>(createFailure(exception));
+			return Fail<TFailure, TSuccess>(createFailure(exception));
 		}
 	}
 
@@ -28,43 +28,43 @@ public static class ResultFactory
 	/// <param name="success">The expected success.</param>
 	/// <param name="predicate">Creates a set of criteria.</param>
 	/// <param name="createFailure">Creates the possible failure.</param>
-	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, a new successful result.</returns>
-	public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(TSuccess success, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)
+	public static Result<TFailure, TSuccess> Ensure<TFailure, TSuccess>(TSuccess success, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)
 		=> Ensure(success, predicate, createFailure(success));
 
 	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, creates a new successful result.</summary>
 	/// <param name="createSuccess">Creates the expected success.</param>
 	/// <param name="predicate">Creates a set of criteria.</param>
 	/// <param name="createFailure">Creates the possible failure.</param>
-	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, a new successful result.</returns>
-	public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(Func<TSuccess> createSuccess, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)
+	public static Result<TFailure, TSuccess> Ensure<TFailure, TSuccess>(Func<TSuccess> createSuccess, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)
 		=> Ensure(createSuccess(), predicate, createFailure);
 
 	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, creates a new successful result.</summary>
 	/// <param name="createSuccess">Creates the expected success.</param>
 	/// <param name="predicate">Creates a set of criteria.</param>
 	/// <param name="failure">The possible failure.</param>
-	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, a new successful result.</returns>
-	public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(Func<TSuccess> createSuccess, Func<TSuccess, bool> predicate, TFailure failure)
+	public static Result<TFailure, TSuccess> Ensure<TFailure, TSuccess>(Func<TSuccess> createSuccess, Func<TSuccess, bool> predicate, TFailure failure)
 		=> Ensure(createSuccess(), predicate, failure);
 
 	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, creates a new successful result.</summary>
 	/// <param name="success">The expected success.</param>
 	/// <param name="predicate">Creates a set of criteria.</param>
 	/// <param name="failure">The possible failure.</param>
-	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, a new successful result.</returns>
-	public static Result<TSuccess, TFailure> Ensure<TSuccess, TFailure>(TSuccess success, Func<TSuccess, bool> predicate, TFailure failure)
+	public static Result<TFailure, TSuccess> Ensure<TFailure, TSuccess>(TSuccess success, Func<TSuccess, bool> predicate, TFailure failure)
 		=> predicate(success)
-			? Fail<TSuccess, TFailure>(failure)
-			: Succeed<TSuccess, TFailure>(success);
+			? Fail<TFailure, TSuccess>(failure)
+			: Succeed<TFailure, TSuccess>(success);
 
 	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, creates a new successful result.</summary>
 	/// <param name="success">The expected success.</param>
@@ -72,10 +72,10 @@ public static class ResultFactory
 	/// <param name="predicate">Creates a set of criteria.</param>
 	/// <param name="createFailure">Creates the possible failure.</param>
 	/// <typeparam name="TAuxiliary">Type of auxiliary.</typeparam>
-	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, a new successful result.</returns>
-	public static Result<TSuccess, TFailure> Ensure<TAuxiliary, TSuccess, TFailure>(TSuccess success, Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
+	public static Result<TFailure, TSuccess> Ensure<TAuxiliary, TFailure, TSuccess>(TSuccess success, Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
 		=> Ensure(success, createAuxiliary(), predicate, createFailure);
 
 	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, creates a new successful result.</summary>
@@ -84,10 +84,10 @@ public static class ResultFactory
 	/// <param name="predicate">Creates a set of criteria.</param>
 	/// <param name="createFailure">Creates the possible failure.</param>
 	/// <typeparam name="TAuxiliary">Type of auxiliary.</typeparam>
-	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, a new successful result.</returns>
-	public static Result<TSuccess, TFailure> Ensure<TAuxiliary, TSuccess, TFailure>(Func<TSuccess> createSuccess, Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
+	public static Result<TFailure, TSuccess> Ensure<TAuxiliary, TFailure, TSuccess>(Func<TSuccess> createSuccess, Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
 		=> Ensure(createSuccess(), createAuxiliary, predicate, createFailure);
 
 	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, creates a new successful result.</summary>
@@ -96,10 +96,10 @@ public static class ResultFactory
 	/// <param name="predicate">Creates a set of criteria.</param>
 	/// <param name="createFailure">Creates the possible failure.</param>
 	/// <typeparam name="TAuxiliary">Type of auxiliary.</typeparam>
-	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, a new successful result.</returns>
-	public static Result<TSuccess, TFailure> Ensure<TAuxiliary, TSuccess, TFailure>(Func<TSuccess> createSuccess, TAuxiliary auxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
+	public static Result<TFailure, TSuccess> Ensure<TAuxiliary, TFailure, TSuccess>(Func<TSuccess> createSuccess, TAuxiliary auxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
 		=> Ensure(createSuccess(), auxiliary, predicate, createFailure);
 
 	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, creates a new successful result.</summary>
@@ -108,44 +108,44 @@ public static class ResultFactory
 	/// <param name="predicate">Creates a set of criteria.</param>
 	/// <param name="createFailure">Creates the possible failure.</param>
 	/// <typeparam name="TAuxiliary">Type of auxiliary.</typeparam>
-	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, a new successful result.</returns>
-	public static Result<TSuccess, TFailure> Ensure<TAuxiliary, TSuccess, TFailure>(TSuccess success, TAuxiliary auxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
+	public static Result<TFailure, TSuccess> Ensure<TAuxiliary, TFailure, TSuccess>(TSuccess success, TAuxiliary auxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
 		=> predicate(success, auxiliary)
-			? Fail<TSuccess, TFailure>(createFailure(success, auxiliary))
-			: Succeed<TSuccess, TFailure>(success);
-
-	/// <summary>Creates a new successful result.</summary>
-	/// <param name="success">The expected success.</param>
-	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
-	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
-	/// <returns>A new successful result.</returns>
-	public static Result<TSuccess, TFailure> Succeed<TSuccess, TFailure>(TSuccess success)
-		=> new(success);
-
-	/// <summary>Creates a new successful result.</summary>
-	/// <param name="createSuccess">Creates the expected success.</param>
-	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
-	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
-	/// <returns>A new successful result.</returns>
-	public static Result<TSuccess, TFailure> Succeed<TSuccess, TFailure>(Func<TSuccess> createSuccess)
-		=> new(createSuccess());
+			? Fail<TFailure, TSuccess>(createFailure(success, auxiliary))
+			: Succeed<TFailure, TSuccess>(success);
 
 	/// <summary>Creates a new failed result.</summary>
 	/// <param name="failure">The possible failure.</param>
-	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <returns>A new failed result.</returns>
-	public static Result<TSuccess, TFailure> Fail<TSuccess, TFailure>(TFailure failure)
+	public static Result<TFailure, TSuccess> Fail<TFailure, TSuccess>(TFailure failure)
 		=> new(failure);
 
 	/// <summary>Creates a new failed result.</summary>
 	/// <param name="createFailure">Creates the possible failure.</param>
-	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
 	/// <returns>A new failed result.</returns>
-	public static Result<TSuccess, TFailure> Fail<TSuccess, TFailure>(Func<TFailure> createFailure)
+	public static Result<TFailure, TSuccess> Fail<TFailure, TSuccess>(Func<TFailure> createFailure)
 		=> new(createFailure());
+
+	/// <summary>Creates a new successful result.</summary>
+	/// <param name="success">The expected success.</param>
+	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
+	/// <returns>A new successful result.</returns>
+	public static Result<TFailure, TSuccess> Succeed<TFailure, TSuccess>(TSuccess success)
+		=> new(success);
+
+	/// <summary>Creates a new successful result.</summary>
+	/// <param name="createSuccess">Creates the expected success.</param>
+	/// <typeparam name="TFailure">Type of possible failure.</typeparam>
+	/// <typeparam name="TSuccess">Type of expected success.</typeparam>
+	/// <returns>A new successful result.</returns>
+	public static Result<TFailure, TSuccess> Succeed<TFailure, TSuccess>(Func<TSuccess> createSuccess)
+		=> new(createSuccess());
 }
 #pragma warning restore CA1062

--- a/test/unit/Monads/Asserters/ResultAsserter.cs
+++ b/test/unit/Monads/Asserters/ResultAsserter.cs
@@ -2,29 +2,29 @@ namespace Daht.Sagitta.Core.UnitTest.Monads.Asserters;
 
 internal static class ResultAsserter
 {
-	internal static void AreSuccessful<TSuccess, TFailure>(TSuccess expectedSuccess, Result<TSuccess, TFailure> actualResult)
-	{
-		IsSuccessful(actualResult);
-		Assert.Equal(expectedSuccess, actualResult.Success);
-		Assert.Equal(default, actualResult.Failure);
-	}
-
-	internal static void IsSuccessful<TSuccess, TFailure>(Result<TSuccess, TFailure> actualResult)
-	{
-		Assert.True(actualResult.IsSuccessful);
-		Assert.False(actualResult.IsFailed);
-	}
-
-	internal static void AreFailed<TSuccess, TFailure>(TFailure expectedFailure, Result<TSuccess, TFailure> actualResult)
+	internal static void AreFailed<TFailure, TSuccess>(TFailure expectedFailure, Result<TFailure, TSuccess> actualResult)
 	{
 		IsFailed(actualResult);
 		Assert.Equal(default, actualResult.Success);
 		Assert.Equal(expectedFailure, actualResult.Failure);
 	}
 
-	internal static void IsFailed<TSuccess, TFailure>(Result<TSuccess, TFailure> actualResult)
+	internal static void IsFailed<TFailure, TSuccess>(Result<TFailure, TSuccess> actualResult)
 	{
 		Assert.False(actualResult.IsSuccessful);
 		Assert.True(actualResult.IsFailed);
+	}
+
+	internal static void AreSuccessful<TFailure, TSuccess>(TSuccess expectedSuccess, Result<TFailure, TSuccess> actualResult)
+	{
+		IsSuccessful(actualResult);
+		Assert.Equal(expectedSuccess, actualResult.Success);
+		Assert.Equal(default, actualResult.Failure);
+	}
+
+	internal static void IsSuccessful<TFailure, TSuccess>(Result<TFailure, TSuccess> actualResult)
+	{
+		Assert.True(actualResult.IsSuccessful);
+		Assert.False(actualResult.IsFailed);
 	}
 }

--- a/test/unit/Monads/Fixtures/ResultFixture.cs
+++ b/test/unit/Monads/Fixtures/ResultFixture.cs
@@ -6,6 +6,9 @@ internal static class ResultFixture
 
 	internal const string Auxiliary = nameof(Auxiliary);
 
+	internal static string RandomFailure
+		=> $"{Failure} | {Guid.NewGuid()}";
+
 	internal static Constellation Success
 		=> new()
 		{
@@ -28,7 +31,4 @@ internal static class ResultFixture
 			Name = "Gamma Sagittae",
 			EvolutionaryStage = "Red Giant"
 		};
-
-	internal static string RandomFailure
-		=> $"{Failure} | {Guid.NewGuid()}";
 }

--- a/test/unit/Monads/Mothers/ResultMother.cs
+++ b/test/unit/Monads/Mothers/ResultMother.cs
@@ -2,18 +2,18 @@ namespace Daht.Sagitta.Core.UnitTest.Monads.Mothers;
 
 internal static class ResultMother
 {
-	internal static Result<Constellation, string> Succeed()
-		=> new(ResultFixture.Success);
-
-	internal static Result<Constellation, string> Succeed(Constellation success)
-		=> new(success);
-
-	internal static Result<Constellation, string> SucceedRandomly()
-		=> new(ResultFixture.RandomSuccess);
-
-	internal static Result<Constellation, string> Fail()
+	internal static Result<string, Constellation> Fail()
 		=> new(ResultFixture.Failure);
 
-	internal static Result<Constellation, string> Fail(string failure)
+	internal static Result<string, Constellation> Fail(string failure)
 		=> new(failure);
+
+	internal static Result<string, Constellation> Succeed()
+		=> new(ResultFixture.Success);
+
+	internal static Result<string, Constellation> Succeed(Constellation success)
+		=> new(success);
+
+	internal static Result<string, Constellation> SucceedRandomly()
+		=> new(ResultFixture.RandomSuccess);
 }

--- a/test/unit/Monads/ResultFactoryTest.cs
+++ b/test/unit/Monads/ResultFactoryTest.cs
@@ -2,20 +2,20 @@ namespace Daht.Sagitta.Core.UnitTest.Monads;
 
 public sealed class ResultFactoryTest
 {
-	private const string root = nameof(ResultFactory);
+	private const string @base = nameof(ResultFactory);
 
 	private const string @catch = nameof(ResultFactory.Catch);
 
 	private const string ensure = nameof(ResultFactory.Ensure);
 
-	private const string succeed = nameof(ResultFactory.Succeed);
-
 	private const string fail = nameof(ResultFactory.Fail);
+
+	private const string succeed = nameof(ResultFactory.Succeed);
 
 	#region Catch
 
 	[Fact]
-	[Trait(root, @catch)]
+	[Trait(@base, @catch)]
 	public void Catch_CreateSuccessPlusCreateFailure_SuccessfulResult()
 	{
 		// Arrange
@@ -24,14 +24,14 @@ public sealed class ResultFactoryTest
 		Func<InvalidOperationException, string> createFailure = static exception => exception.Message;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Catch(createSuccess, createFailure);
+		Result<string, Constellation> actualResult = ResultFactory.Catch(createSuccess, createFailure);
 
 		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
 	}
 
 	[Fact]
-	[Trait(root, @catch)]
+	[Trait(@base, @catch)]
 	public void Catch_ExceptionPlusCreateFailure_FailedResult()
 	{
 		// Arrange
@@ -40,7 +40,7 @@ public sealed class ResultFactoryTest
 		const string expectedFailure = "Operation is not valid due to the current state of the object.";
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Catch(createSuccess, createFailure);
+		Result<string, Constellation> actualResult = ResultFactory.Catch(createSuccess, createFailure);
 
 		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
@@ -53,7 +53,7 @@ public sealed class ResultFactoryTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_SuccessPlusTruePredicatePlusCreateFailure_FailedResult()
 	{
 		// Arrange
@@ -63,14 +63,14 @@ public sealed class ResultFactoryTest
 		Func<Constellation, string> createFailure = static _ => expectedFailure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(success, predicate, createFailure);
+		Result<string, Constellation> actualResult = ResultFactory.Ensure(success, predicate, createFailure);
 
 		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_SuccessPlusFalsePredicatePlusCreateFailure_SuccessfulResult()
 	{
 		// Arrange
@@ -79,7 +79,7 @@ public sealed class ResultFactoryTest
 		Func<Constellation, string> createFailure = static _ => ResultFixture.Failure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(expectedSuccess, predicate, createFailure);
+		Result<string, Constellation> actualResult = ResultFactory.Ensure(expectedSuccess, predicate, createFailure);
 
 		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
@@ -90,7 +90,7 @@ public sealed class ResultFactoryTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_CreateSuccessPlusTruePredicatePlusCreateFailure_FailedResult()
 	{
 		// Arrange
@@ -100,14 +100,14 @@ public sealed class ResultFactoryTest
 		Func<Constellation, string> createFailure = static _ => expectedFailure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(createSuccess, predicate, createFailure);
+		Result<string, Constellation> actualResult = ResultFactory.Ensure(createSuccess, predicate, createFailure);
 
 		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_CreateSuccessPlusFalsePredicatePlusCreateFailure_SuccessfulResult()
 	{
 		// Arrange
@@ -117,7 +117,7 @@ public sealed class ResultFactoryTest
 		Func<Constellation, string> createFailure = static _ => ResultFixture.Failure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(createSuccess, predicate, createFailure);
+		Result<string, Constellation> actualResult = ResultFactory.Ensure(createSuccess, predicate, createFailure);
 
 		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
@@ -128,7 +128,7 @@ public sealed class ResultFactoryTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_CreateSuccessPlusTruePredicatePlusFailure_FailedResult()
 	{
 		// Arrange
@@ -137,14 +137,14 @@ public sealed class ResultFactoryTest
 		const string expectedFailure = ResultFixture.Failure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(createSuccess, predicate, expectedFailure);
+		Result<string, Constellation> actualResult = ResultFactory.Ensure(createSuccess, predicate, expectedFailure);
 
 		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_CreateSuccessPlusFalsePredicatePlusFailure_SuccessfulResult()
 	{
 		// Arrange
@@ -154,7 +154,7 @@ public sealed class ResultFactoryTest
 		const string failure = ResultFixture.Failure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(createSuccess, predicate, failure);
+		Result<string, Constellation> actualResult = ResultFactory.Ensure(createSuccess, predicate, failure);
 
 		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
@@ -165,7 +165,7 @@ public sealed class ResultFactoryTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_SuccessPlusTruePredicatePlusFailure_FailedResult()
 	{
 		// Arrange
@@ -174,14 +174,14 @@ public sealed class ResultFactoryTest
 		const string expectedFailure = ResultFixture.Failure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(success, predicate, expectedFailure);
+		Result<string, Constellation> actualResult = ResultFactory.Ensure(success, predicate, expectedFailure);
 
 		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_SuccessPlusFalsePredicatePlusFailure_SuccessfulResult()
 	{
 		// Arrange
@@ -190,7 +190,7 @@ public sealed class ResultFactoryTest
 		const string failure = ResultFixture.Failure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(expectedSuccess, predicate, failure);
+		Result<string, Constellation> actualResult = ResultFactory.Ensure(expectedSuccess, predicate, failure);
 
 		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
@@ -201,7 +201,7 @@ public sealed class ResultFactoryTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_SuccessPlusCreateAuxiliaryPlusTruePredicatePlusCreateFailure_FailedResult()
 	{
 		// Arrange
@@ -212,14 +212,14 @@ public sealed class ResultFactoryTest
 		Func<Constellation, string, string> createFailure = static (_, _) => expectedFailure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(success, createAuxiliary, predicate, createFailure);
+		Result<string, Constellation> actualResult = ResultFactory.Ensure(success, createAuxiliary, predicate, createFailure);
 
 		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_SuccessPlusCreateAuxiliaryPlusFalsePredicatePlusCreateFailure_SuccessfulResult()
 	{
 		// Arrange
@@ -229,7 +229,7 @@ public sealed class ResultFactoryTest
 		Func<Constellation, string, string> createFailure = static (_, _) => ResultFixture.Failure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(expectedSuccess, createAuxiliary, predicate, createFailure);
+		Result<string, Constellation> actualResult = ResultFactory.Ensure(expectedSuccess, createAuxiliary, predicate, createFailure);
 
 		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
@@ -240,7 +240,7 @@ public sealed class ResultFactoryTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_CreateSuccessPlusCreateAuxiliaryPlusTruePredicatePlusCreateFailure_FailedResult()
 	{
 		// Arrange
@@ -251,14 +251,14 @@ public sealed class ResultFactoryTest
 		Func<Constellation, string, string> createFailure = static (_, _) => expectedFailure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(createSuccess, createAuxiliary, predicate, createFailure);
+		Result<string, Constellation> actualResult = ResultFactory.Ensure(createSuccess, createAuxiliary, predicate, createFailure);
 
 		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_CreateSuccessPlusCreateAuxiliaryPlusFalsePredicatePlusCreateFailure_SuccessfulResult()
 	{
 		// Arrange
@@ -269,7 +269,7 @@ public sealed class ResultFactoryTest
 		Func<Constellation, string, string> createFailure = static (_, _) => ResultFixture.Failure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(createSuccess, createAuxiliary, predicate, createFailure);
+		Result<string, Constellation> actualResult = ResultFactory.Ensure(createSuccess, createAuxiliary, predicate, createFailure);
 
 		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
@@ -280,7 +280,7 @@ public sealed class ResultFactoryTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_CreateSuccessPlusAuxiliaryPlusTruePredicatePlusCreateFailure_FailedResult()
 	{
 		// Arrange
@@ -291,14 +291,14 @@ public sealed class ResultFactoryTest
 		Func<Constellation, string, string> createFailure = static (_, _) => expectedFailure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(createSuccess, auxiliary, predicate, createFailure);
+		Result<string, Constellation> actualResult = ResultFactory.Ensure(createSuccess, auxiliary, predicate, createFailure);
 
 		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_CreateSuccessPlusAuxiliaryPlusFalsePredicatePlusCreateFailure_SuccessfulResult()
 	{
 		// Arrange
@@ -309,7 +309,7 @@ public sealed class ResultFactoryTest
 		Func<Constellation, string, string> createFailure = static (_, _) => ResultFixture.Failure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(createSuccess, auxiliary, predicate, createFailure);
+		Result<string, Constellation> actualResult = ResultFactory.Ensure(createSuccess, auxiliary, predicate, createFailure);
 
 		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
@@ -320,7 +320,7 @@ public sealed class ResultFactoryTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_SuccessPlusAuxiliaryPlusTruePredicatePlusCreateFailure_FailedResult()
 	{
 		// Arrange
@@ -331,14 +331,14 @@ public sealed class ResultFactoryTest
 		Func<Constellation, string, string> createFailure = static (_, _) => expectedFailure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(success, auxiliary, predicate, createFailure);
+		Result<string, Constellation> actualResult = ResultFactory.Ensure(success, auxiliary, predicate, createFailure);
 
 		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_SuccessPlusAuxiliaryPlusFalsePredicatePlusCreateFailure_SuccessfulResult()
 	{
 		// Arrange
@@ -348,48 +348,7 @@ public sealed class ResultFactoryTest
 		Func<Constellation, string, string> createFailure = static (_, _) => ResultFixture.Failure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Ensure(expectedSuccess, auxiliary, predicate, createFailure);
-
-		// Assert
-		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
-	}
-
-	#endregion
-
-	#endregion
-
-	#region Succeed
-
-	#region Overload
-
-	[Fact]
-	[Trait(root, succeed)]
-	public void Succeed_Success_SuccessfulResult()
-	{
-		// Arrange
-		Constellation expectedSuccess = ResultFixture.Success;
-
-		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Succeed<Constellation, string>(expectedSuccess);
-
-		// Assert
-		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
-	}
-
-	#endregion
-
-	#region Overload
-
-	[Fact]
-	[Trait(root, succeed)]
-	public void Succeed_CreateSuccess_SuccessfulResult()
-	{
-		// Arrange
-		Constellation expectedSuccess = ResultFixture.Success;
-		Func<Constellation> createSuccess = () => expectedSuccess;
-
-		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Succeed<Constellation, string>(createSuccess);
+		Result<string, Constellation> actualResult = ResultFactory.Ensure(expectedSuccess, auxiliary, predicate, createFailure);
 
 		// Assert
 		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
@@ -404,14 +363,14 @@ public sealed class ResultFactoryTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, fail)]
+	[Trait(@base, fail)]
 	public void Fail_Failure_FailedResult()
 	{
 		// Arrange
 		const string expectedFailure = ResultFixture.Failure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Fail<Constellation, string>(expectedFailure);
+		Result<string, Constellation> actualResult = ResultFactory.Fail<string, Constellation>(expectedFailure);
 
 		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
@@ -422,7 +381,7 @@ public sealed class ResultFactoryTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, fail)]
+	[Trait(@base, fail)]
 	public void Fail_CreateFailure_FailedResult()
 	{
 		// Arrange
@@ -430,10 +389,51 @@ public sealed class ResultFactoryTest
 		Func<string> createFailure = static () => expectedFailure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultFactory.Fail<Constellation, string>(createFailure);
+		Result<string, Constellation> actualResult = ResultFactory.Fail<string, Constellation>(createFailure);
 
 		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	#endregion
+
+	#endregion
+
+	#region Succeed
+
+	#region Overload
+
+	[Fact]
+	[Trait(@base, succeed)]
+	public void Succeed_Success_SuccessfulResult()
+	{
+		// Arrange
+		Constellation expectedSuccess = ResultFixture.Success;
+
+		// Act
+		Result<string, Constellation> actualResult = ResultFactory.Succeed<string, Constellation>(expectedSuccess);
+
+		// Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
+
+	#endregion
+
+	#region Overload
+
+	[Fact]
+	[Trait(@base, succeed)]
+	public void Succeed_CreateSuccess_SuccessfulResult()
+	{
+		// Arrange
+		Constellation expectedSuccess = ResultFixture.Success;
+		Func<Constellation> createSuccess = () => expectedSuccess;
+
+		// Act
+		Result<string, Constellation> actualResult = ResultFactory.Succeed<string, Constellation>(createSuccess);
+
+		// Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
 	}
 
 	#endregion

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -2,7 +2,7 @@ namespace Daht.Sagitta.Core.UnitTest.Monads;
 
 public sealed class ResultTest
 {
-	private const string root = nameof(Result<object, object>);
+	private const string @base = nameof(Result<object, object>);
 
 	private const string constructor = "Constructor";
 
@@ -10,9 +10,9 @@ public sealed class ResultTest
 
 	private const string ensure = nameof(Result<object, object>.Ensure);
 
-	private const string doOnSuccess = nameof(Result<object, object>.DoOnSuccess);
-
 	private const string doOnFailure = nameof(Result<object, object>.DoOnFailure);
+
+	private const string doOnSuccess = nameof(Result<object, object>.DoOnSuccess);
 
 	private const string map = nameof(Result<object, object>.Map);
 
@@ -25,17 +25,17 @@ public sealed class ResultTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, constructor)]
-	public void Constructor_Success_SuccessfulResult()
+	[Trait(@base, constructor)]
+	public void Constructor_Failure_FailedResult()
 	{
 		// Arrange
-		Constellation expectedSuccess = ResultFixture.Success;
+		const string expectedFailure = ResultFixture.Failure;
 
 		// Act
-		Result<Constellation, string> actualResult = new(expectedSuccess);
+		Result<string, Constellation> actualResult = new(expectedFailure);
 
 		// Assert
-		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
 
 	#endregion
@@ -43,17 +43,17 @@ public sealed class ResultTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, constructor)]
-	public void Constructor_Failure_FailedResult()
+	[Trait(@base, constructor)]
+	public void Constructor_Success_SuccessfulResult()
 	{
 		// Arrange
-		const string expectedFailure = ResultFixture.Failure;
+		Constellation expectedSuccess = ResultFixture.Success;
 
 		// Act
-		Result<Constellation, string> actualResult = new(expectedFailure);
+		Result<string, Constellation> actualResult = new(expectedSuccess);
 
 		// Assert
-		ResultAsserter.AreFailed(expectedFailure, actualResult);
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
 	}
 
 	#endregion
@@ -65,17 +65,17 @@ public sealed class ResultTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, implicitOperator)]
-	public void ImplicitOperator_Success_SuccessfulResult()
+	[Trait(@base, implicitOperator)]
+	public void ImplicitOperator_Failure_FailedResult()
 	{
 		// Arrange
-		Constellation expectedSuccess = ResultFixture.Success;
+		const string expectedFailure = ResultFixture.Failure;
 
 		// Act
-		Result<Constellation, string> actualResult = expectedSuccess;
+		Result<string, Constellation> actualResult = expectedFailure;
 
 		// Assert
-		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
 
 	#endregion
@@ -83,17 +83,17 @@ public sealed class ResultTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, implicitOperator)]
-	public void ImplicitOperator_Failure_FailedResult()
+	[Trait(@base, implicitOperator)]
+	public void ImplicitOperator_Success_SuccessfulResult()
 	{
 		// Arrange
-		const string expectedFailure = ResultFixture.Failure;
+		Constellation expectedSuccess = ResultFixture.Success;
 
 		// Act
-		Result<Constellation, string> actualResult = expectedFailure;
+		Result<string, Constellation> actualResult = expectedSuccess;
 
 		// Assert
-		ResultAsserter.AreFailed(expectedFailure, actualResult);
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
 	}
 
 	#endregion
@@ -105,7 +105,7 @@ public sealed class ResultTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_FailedResultPlusTruePredicatePlusCreateFailure_FailedResult()
 	{
 		// Arrange
@@ -114,7 +114,7 @@ public sealed class ResultTest
 		Func<Constellation, string> createFailure = static _ => ResultFixture.RandomFailure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultMother.Fail(expectedFailure)
+		Result<string, Constellation> actualResult = ResultMother.Fail(expectedFailure)
 			.Ensure(predicate, createFailure);
 
 		// Assert
@@ -122,7 +122,7 @@ public sealed class ResultTest
 	}
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_SuccessfulResultPlusTruePredicatePlusCreateFailure_FailedResult()
 	{
 		// Arrange
@@ -131,7 +131,7 @@ public sealed class ResultTest
 		Func<Constellation, string> createFailure = static _ => expectedFailure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultMother.Succeed()
+		Result<string, Constellation> actualResult = ResultMother.Succeed()
 			.Ensure(predicate, createFailure);
 
 		// Assert
@@ -139,7 +139,7 @@ public sealed class ResultTest
 	}
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_SuccessfulResultPlusFalsePredicatePlusCreateFailure_SuccessfulResult()
 	{
 		// Arrange
@@ -148,7 +148,7 @@ public sealed class ResultTest
 		Func<Constellation, string> createFailure = static _ => ResultFixture.Failure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultMother.Succeed(expectedSuccess)
+		Result<string, Constellation> actualResult = ResultMother.Succeed(expectedSuccess)
 			.Ensure(predicate, createFailure);
 
 		// Assert
@@ -160,7 +160,7 @@ public sealed class ResultTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_FailedResultPlusTruePredicatePlusFailure_FailedResult()
 	{
 		// Arrange
@@ -169,7 +169,7 @@ public sealed class ResultTest
 		string failure = ResultFixture.RandomFailure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultMother.Fail(expectedFailure)
+		Result<string, Constellation> actualResult = ResultMother.Fail(expectedFailure)
 			.Ensure(predicate, failure);
 
 		// Assert
@@ -177,7 +177,7 @@ public sealed class ResultTest
 	}
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_SuccessfulResultPlusTruePredicatePlusFailure_FailedResult()
 	{
 		// Arrange
@@ -185,7 +185,7 @@ public sealed class ResultTest
 		const string expectedFailure = ResultFixture.Failure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultMother.Succeed()
+		Result<string, Constellation> actualResult = ResultMother.Succeed()
 			.Ensure(predicate, expectedFailure);
 
 		// Assert
@@ -193,7 +193,7 @@ public sealed class ResultTest
 	}
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_SuccessfulResultPlusFalsePredicatePlusFailure_SuccessfulResult()
 	{
 		// Arrange
@@ -202,7 +202,7 @@ public sealed class ResultTest
 		const string failure = ResultFixture.Failure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultMother.Succeed(expectedSuccess)
+		Result<string, Constellation> actualResult = ResultMother.Succeed(expectedSuccess)
 			.Ensure(predicate, failure);
 
 		// Assert
@@ -214,7 +214,7 @@ public sealed class ResultTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_FailedResultPlusCreateAuxiliaryPlusTruePredicatePlusCreateFailure_FailedResult()
 	{
 		// Arrange
@@ -224,7 +224,7 @@ public sealed class ResultTest
 		Func<Constellation, string, string> createFailure = static (_, _) => ResultFixture.RandomFailure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultMother.Fail(expectedFailure)
+		Result<string, Constellation> actualResult = ResultMother.Fail(expectedFailure)
 			.Ensure(createAuxiliary, predicate, createFailure);
 
 		// Assert
@@ -232,7 +232,7 @@ public sealed class ResultTest
 	}
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_SuccessfulResultPlusCreateAuxiliaryPlusTruePredicatePlusCreateFailure_FailedResult()
 	{
 		// Arrange
@@ -242,7 +242,7 @@ public sealed class ResultTest
 		Func<Constellation, string, string> createFailure = static (_, _) => expectedFailure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultMother.Succeed()
+		Result<string, Constellation> actualResult = ResultMother.Succeed()
 			.Ensure(createAuxiliary, predicate, createFailure);
 
 		// Assert
@@ -250,7 +250,7 @@ public sealed class ResultTest
 	}
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_SuccessfulResultPlusCreateAuxiliaryPlusFalsePredicatePlusCreateFailure_SuccessfulResult()
 	{
 		// Arrange
@@ -260,7 +260,7 @@ public sealed class ResultTest
 		Func<Constellation, string, string> createFailure = static (_, _) => ResultFixture.Failure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultMother.Succeed(expectedSuccess)
+		Result<string, Constellation> actualResult = ResultMother.Succeed(expectedSuccess)
 			.Ensure(createAuxiliary, predicate, createFailure);
 
 		// Assert
@@ -272,7 +272,7 @@ public sealed class ResultTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_FailedResultPlusAuxiliaryPlusTruePredicatePlusCreateFailure_FailedResult()
 	{
 		// Arrange
@@ -282,7 +282,7 @@ public sealed class ResultTest
 		Func<Constellation, string, string> createFailure = static (_, _) => ResultFixture.RandomFailure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultMother.Fail(expectedFailure)
+		Result<string, Constellation> actualResult = ResultMother.Fail(expectedFailure)
 			.Ensure(auxiliary, predicate, createFailure);
 
 		// Assert
@@ -290,7 +290,7 @@ public sealed class ResultTest
 	}
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_SuccessfulResultPlusAuxiliaryPlusTruePredicatePlusCreateFailure_FailedResult()
 	{
 		// Arrange
@@ -300,7 +300,7 @@ public sealed class ResultTest
 		Func<Constellation, string, string> createFailure = static (_, _) => expectedFailure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultMother.Succeed()
+		Result<string, Constellation> actualResult = ResultMother.Succeed()
 			.Ensure(auxiliary, predicate, createFailure);
 
 		// Assert
@@ -308,7 +308,7 @@ public sealed class ResultTest
 	}
 
 	[Fact]
-	[Trait(root, ensure)]
+	[Trait(@base, ensure)]
 	public void Ensure_SuccessfulResultPlusAuxiliaryPlusFalsePredicatePlusCreateFailure_SuccessfulResult()
 	{
 		// Arrange
@@ -318,7 +318,7 @@ public sealed class ResultTest
 		Func<Constellation, string, string> createFailure = static (_, _) => ResultFixture.Failure;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultMother.Succeed(expectedSuccess)
+		Result<string, Constellation> actualResult = ResultMother.Succeed(expectedSuccess)
 			.Ensure(auxiliary, predicate, createFailure);
 
 		// Assert
@@ -329,48 +329,10 @@ public sealed class ResultTest
 
 	#endregion
 
-	#region DoOnSuccess
-
-	[Fact]
-	[Trait(root, doOnSuccess)]
-	public void DoOnSuccess_FailedResultPlusExecute_FailedResult()
-	{
-		// Arrange
-		bool status = false;
-		Action<Constellation> execute = _ => status = true;
-
-		// Act
-		Result<Constellation, string> actualResult = ResultMother.Fail()
-			.DoOnSuccess(execute);
-
-		// Assert
-		Assert.False(status);
-		ResultAsserter.IsFailed(actualResult);
-	}
-
-	[Fact]
-	[Trait(root, doOnSuccess)]
-	public void DoOnSuccess_SuccessfulResultPlusExecute_SuccessfulResult()
-	{
-		// Arrange
-		bool status = false;
-		Action<Constellation> execute = _ => status = true;
-
-		// Act
-		Result<Constellation, string> actualResult = ResultMother.Succeed()
-			.DoOnSuccess(execute);
-
-		// Assert
-		Assert.True(status);
-		ResultAsserter.IsSuccessful(actualResult);
-	}
-
-	#endregion
-
 	#region DoOnFailure
 
 	[Fact]
-	[Trait(root, doOnFailure)]
+	[Trait(@base, doOnFailure)]
 	public void DoOnFailure_SuccessfulResultPlusExecute_SuccessfulResult()
 	{
 		// Arrange
@@ -378,7 +340,7 @@ public sealed class ResultTest
 		Action<string> execute = _ => status = true;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultMother.Succeed()
+		Result<string, Constellation> actualResult = ResultMother.Succeed()
 			.DoOnFailure(execute);
 
 		// Assert
@@ -387,7 +349,7 @@ public sealed class ResultTest
 	}
 
 	[Fact]
-	[Trait(root, doOnFailure)]
+	[Trait(@base, doOnFailure)]
 	public void DoOnFailure_FailedResultPlusExecute_FailedResult()
 	{
 		// Arrange
@@ -395,12 +357,50 @@ public sealed class ResultTest
 		Action<string> execute = _ => status = true;
 
 		// Act
-		Result<Constellation, string> actualResult = ResultMother.Fail()
+		Result<string, Constellation> actualResult = ResultMother.Fail()
 			.DoOnFailure(execute);
 
 		// Assert
 		Assert.True(status);
 		ResultAsserter.IsFailed(actualResult);
+	}
+
+	#endregion
+
+	#region DoOnSuccess
+
+	[Fact]
+	[Trait(@base, doOnSuccess)]
+	public void DoOnSuccess_FailedResultPlusExecute_FailedResult()
+	{
+		// Arrange
+		bool status = false;
+		Action<Constellation> execute = _ => status = true;
+
+		// Act
+		Result<string, Constellation> actualResult = ResultMother.Fail()
+			.DoOnSuccess(execute);
+
+		// Assert
+		Assert.False(status);
+		ResultAsserter.IsFailed(actualResult);
+	}
+
+	[Fact]
+	[Trait(@base, doOnSuccess)]
+	public void DoOnSuccess_SuccessfulResultPlusExecute_SuccessfulResult()
+	{
+		// Arrange
+		bool status = false;
+		Action<Constellation> execute = _ => status = true;
+
+		// Act
+		Result<string, Constellation> actualResult = ResultMother.Succeed()
+			.DoOnSuccess(execute);
+
+		// Assert
+		Assert.True(status);
+		ResultAsserter.IsSuccessful(actualResult);
 	}
 
 	#endregion
@@ -410,7 +410,7 @@ public sealed class ResultTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, map)]
+	[Trait(@base, map)]
 	public void Map_FailedResultPlusCreateSuccessToMap_FailedResult()
 	{
 		// Arrange
@@ -418,7 +418,7 @@ public sealed class ResultTest
 		Func<Constellation, Start> createSuccessToMap = static _ => ResultFixture.SuccessToMap;
 
 		// Act
-		Result<Start, string> actualResult = ResultMother.Fail(expectedFailure)
+		Result<string, Start> actualResult = ResultMother.Fail(expectedFailure)
 			.Map(createSuccessToMap);
 
 		// Assert
@@ -426,7 +426,7 @@ public sealed class ResultTest
 	}
 
 	[Fact]
-	[Trait(root, map)]
+	[Trait(@base, map)]
 	public void Map_SuccessfulResultPlusCreateSuccessToMap_SuccessfulResult()
 	{
 		// Arrange
@@ -434,7 +434,7 @@ public sealed class ResultTest
 		Func<Constellation, Start> createSuccessToMap = _ => expectedSuccess;
 
 		// Act
-		Result<Start, string> actualResult = ResultMother.Succeed()
+		Result<string, Start> actualResult = ResultMother.Succeed()
 			.Map(createSuccessToMap);
 
 		// Assert
@@ -446,7 +446,7 @@ public sealed class ResultTest
 	#region Overload
 
 	[Fact]
-	[Trait(root, map)]
+	[Trait(@base, map)]
 	public void Map_FailedResultPlusSuccessToMap_FailedResult()
 	{
 		// Arrange
@@ -454,7 +454,7 @@ public sealed class ResultTest
 		Start successToMap = ResultFixture.SuccessToMap;
 
 		// Act
-		Result<Start, string> actualResult = ResultMother.Fail(expectedFailure)
+		Result<string, Start> actualResult = ResultMother.Fail(expectedFailure)
 			.Map(successToMap);
 
 		// Assert
@@ -462,14 +462,14 @@ public sealed class ResultTest
 	}
 
 	[Fact]
-	[Trait(root, map)]
+	[Trait(@base, map)]
 	public void Map_SuccessfulResultPlusSuccessToMap_SuccessfulResult()
 	{
 		// Arrange
 		Start expectedSuccess = ResultFixture.SuccessToMap;
 
 		// Act
-		Result<Start, string> actualResult = ResultMother.Succeed()
+		Result<string, Start> actualResult = ResultMother.Succeed()
 			.Map(expectedSuccess);
 
 		// Assert
@@ -483,15 +483,15 @@ public sealed class ResultTest
 	#region Bind
 
 	[Fact]
-	[Trait(root, bind)]
+	[Trait(@base, bind)]
 	public void Bind_FailedResultPlusCreateResultToBindWithSuccessfulResult_FailedResult()
 	{
 		// Arrange
 		const string expectedFailure = ResultFixture.Failure;
-		Func<Constellation, Result<Constellation, string>> createResultToBind = static _ => ResultMother.Succeed();
+		Func<Constellation, Result<string, Constellation>> createResultToBind = static _ => ResultMother.Succeed();
 
 		// Act
-		Result<Constellation, string> actualResult = ResultMother.Fail(expectedFailure)
+		Result<string, Constellation> actualResult = ResultMother.Fail(expectedFailure)
 			.Bind(createResultToBind);
 
 		// Assert
@@ -499,15 +499,15 @@ public sealed class ResultTest
 	}
 
 	[Fact]
-	[Trait(root, bind)]
+	[Trait(@base, bind)]
 	public void Bind_SuccessfulResultPlusCreateResultToBindWithFailedResult_FailedResult()
 	{
 		// Arrange
 		const string expectedFailure = ResultFixture.Failure;
-		Func<Constellation, Result<Constellation, string>> createResultToBind = static _ => ResultMother.Fail(expectedFailure);
+		Func<Constellation, Result<string, Constellation>> createResultToBind = static _ => ResultMother.Fail(expectedFailure);
 
 		// Act
-		Result<Constellation, string> actualResult = ResultMother.Succeed()
+		Result<string, Constellation> actualResult = ResultMother.Succeed()
 			.Bind(createResultToBind);
 
 		// Assert
@@ -515,15 +515,15 @@ public sealed class ResultTest
 	}
 
 	[Fact]
-	[Trait(root, bind)]
+	[Trait(@base, bind)]
 	public void Bind_SuccessfulResultPlusCreateResultToBindWithSuccessfulResult_SuccessfulResult()
 	{
 		// Arrange
 		Constellation expectedSuccess = ResultFixture.Success;
-		Func<Constellation, Result<Constellation, string>> createResultToBind = _ => ResultMother.Succeed(expectedSuccess);
+		Func<Constellation, Result<string, Constellation>> createResultToBind = _ => ResultMother.Succeed(expectedSuccess);
 
 		// Act
-		Result<Constellation, string> actualResult = ResultMother.SucceedRandomly()
+		Result<string, Constellation> actualResult = ResultMother.SucceedRandomly()
 			.Bind(createResultToBind);
 
 		// Assert
@@ -535,7 +535,7 @@ public sealed class ResultTest
 	#region Reduce
 
 	[Fact]
-	[Trait(root, reduce)]
+	[Trait(@base, reduce)]
 	public void Reduce_FailedResultPlusCreateReducedSuccessPlusCreateReducedFailure_ReducedFailure()
 	{
 		// Arrange
@@ -552,7 +552,7 @@ public sealed class ResultTest
 	}
 
 	[Fact]
-	[Trait(root, reduce)]
+	[Trait(@base, reduce)]
 	public void Reduce_SuccessfulResultPlusCreateReducedSuccessPlusCreateReducedFailure_ReducedSuccess()
 	{
 		// Arrange


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta-core/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta-core/blob/main/contributing.md).

## Table of contents

1. [Tickets](#tickets)
2. [Description](#description)
3. [Additional information](#additional-information)

### Tickets

<!-- Provide related issue tickets | Optional -->

Undefined.

***[Top](#pull-request)***

### Description

<!-- Provide a concise and clear description | Required -->

The generics of the [`Result`](https://github.com/daht-x/sagitta-core/blob/main/source/Monads/Result.cs) type were inverted from `<TSuccess, TFailure>` to `<TFailure, TSuccess>` to prioritize and guide a workflow towards the early detection of the potential or possible failures, improving the readability, accessibility, maintainability and scalability of both the library and those who use it. For more information, please see:

- [The fail fast principle](https://www.codereliant.io/fail-fast-pattern).
- [The guard clauses statements](https://en.wikipedia.org/wiki/Guard_(computer_science)).

***[Top](#pull-request)***

### Additional information

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

Undefined.

***[Top](#pull-request)***
