### PR TITLE
compatibility(`Result`): invert parameters position of the `Reduce` method

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -134,13 +134,13 @@ public sealed class Result<TFailure, TSuccess>
 			: createResultToBind(Success);
 
 	/// <summary>Creates a new reduced failure if the previous result is failed; otherwise, creates a new reduced success.</summary>
-	/// <param name="createReducedSuccess">Creates the expected reduced success.</param>
-	/// <param name="createReducedFailure">Creates the possible reduced failure.</param>
+	/// <param name="reduceFailure">Creates the possible reduced failure.</param>
+	/// <param name="reduceSuccess">Creates the expected reduced success.</param>
 	/// <typeparam name="TReducer">Type of reducer.</typeparam>
 	/// <returns>A new reduced failure if the previous result is failed; otherwise, a new reduced success.</returns>
-	public TReducer Reduce<TReducer>(Func<TSuccess, TReducer> createReducedSuccess, Func<TFailure, TReducer> createReducedFailure)
+	public TReducer Reduce<TReducer>(Func<TFailure, TReducer> reduceFailure, Func<TSuccess, TReducer> reduceSuccess)
 		=> IsFailed
-			? createReducedFailure(Failure)
-			: createReducedSuccess(Success);
+			? reduceFailure(Failure)
+			: reduceSuccess(Success);
 }
 #pragma warning restore CA1062

--- a/test/unit/Monads/ResultTest.cs
+++ b/test/unit/Monads/ResultTest.cs
@@ -536,16 +536,16 @@ public sealed class ResultTest
 
 	[Fact]
 	[Trait(@base, reduce)]
-	public void Reduce_FailedResultPlusCreateReducedSuccessPlusCreateReducedFailure_ReducedFailure()
+	public void Reduce_FailedResultPlusReduceFailurePlusReduceSuccess_ReducedFailure()
 	{
 		// Arrange
 		object expectedReduction = ResultFixture.Failure;
-		Func<Constellation, object> createReducedSuccess = static _ => ResultFixture.Success;
-		Func<string, object> createReducedFailure = _ => expectedReduction;
+		Func<string, object> reduceFailure = _ => expectedReduction;
+		Func<Constellation, object> reduceSuccess = static _ => ResultFixture.Success;
 
 		// Act
 		object actualReduction = ResultMother.Fail()
-			.Reduce(createReducedSuccess, createReducedFailure);
+			.Reduce(reduceFailure, reduceSuccess);
 
 		// Assert
 		Assert.Equal(expectedReduction, actualReduction);
@@ -553,16 +553,16 @@ public sealed class ResultTest
 
 	[Fact]
 	[Trait(@base, reduce)]
-	public void Reduce_SuccessfulResultPlusCreateReducedSuccessPlusCreateReducedFailure_ReducedSuccess()
+	public void Reduce_SuccessfulResultPlusReduceFailurePlusReduceSuccess_ReducedSuccess()
 	{
 		// Arrange
 		Constellation expectedReduction = ResultFixture.Success;
-		Func<Constellation, object> createReducedSuccess = _ => expectedReduction;
-		Func<string, object> createReducedFailure = static _ => ResultFixture.Failure;
+		Func<string, object> reduceFailure = static _ => ResultFixture.Failure;
+		Func<Constellation, object> reduceSuccess = _ => expectedReduction;
 
 		// Act
 		object actualReduction = ResultMother.Succeed()
-			.Reduce(createReducedSuccess, createReducedFailure);
+			.Reduce(reduceFailure, reduceSuccess);
 
 		// Assert
 		Assert.Equal(expectedReduction, actualReduction);


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta-core/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta-core/blob/main/contributing.md).

## Table of contents

1. [Tickets](#tickets)
2. [Description](#description)
3. [Additional information](#additional-information)

### Tickets

<!-- Provide related issue tickets | Optional -->

Undefined.

***[Top](#pull-request)***

### Description

<!-- Provide a concise and clear description | Required -->

The parameters of the "Reduce" method were inverted from `(reduceSuccess, reduceFailure)` to `(reduceFailure, reduceSuccess)` to follow the methodology proposed in pull request #257.

***[Top](#pull-request)***

### Additional information

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

Undefined.

***[Top](#pull-request)***
