### PR TITLE
documentation: synchronize information provided by the API

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -147,8 +147,8 @@ For answers to common questions about this code of conduct, see the FAQ at
 
 ### Additional resources
 
-- [License](./license).
-- [Security policy](./security.md).
-- [Contributing guidelines](./contributing.md).
+- [License](./license)
+- [Security policy](./security.md)
+- [Contributing guidelines](./contributing.md)
 
 ***[Top](#code-of-conduct)***

--- a/contributing.md
+++ b/contributing.md
@@ -61,6 +61,6 @@ Please read and keep in mind our [security policy](./security.md).
 
 ### Additional resources
 
-- [License](./license).
+- [License](./license)
 
 ***[Top](#contributing-guidelines)***

--- a/documentation/monads/result-factory.md
+++ b/documentation/monads/result-factory.md
@@ -1,188 +1,339 @@
-# `static class ResultFactory`
+# `ResultFactory`
 
 ***[home](../../readme.md) / monads /***
 
-Type that exposes a set of ways to initialize [`Result<TSuccess, TFailure>`](./result.md).
+```cs
+public static class ResultFactory
+ ```
+
+Type intended to expose a set of ways to initialize [`Result<TFailure, TSuccess>`](./result.md).
 
 ## Table of contents
 
 1. [Methods](#methods)
-   - [`Catch`](#catch)
-   - [`Ensure`](#ensure)
-   - [`Succeed`](#succeed)
-   - [`Fail`](#fail)
+   - [`Fail<TFailure, TSuccess>(failure)`](#failtfailure-tsuccessfailure)
+   - [`Fail<TFailure, TSuccess>(createFailure)`](#failtfailure-tsuccesscreatefailure)
+   - [`Succeed<TFailure, TSuccess>(success)`](#succeedtfailure-tsuccesssuccess)
+   - [`Succeed<TFailure, TSuccess>(createSuccess)`](#succeedtfailure-tsuccesscreatesuccess)
+   - [`Catch<TException, TFailure, TSuccess>(createSuccess, createFailure)`](#catchtexception-tfailure-tsuccesscreatesuccess-createfailure)
+   - [`Ensure<TFailure, TSuccess>(success, predicate, failure)`](#ensuretfailure-tsuccesssuccess-predicate-failure)
+   - [`Ensure<TFailure, TSuccess>(success, predicate, createFailure)`](#ensuretfailure-tsuccesssuccess-predicate-createfailure)
+   - [`Ensure<TFailure, TSuccess>(createSuccess, predicate, failure)`](#ensuretfailure-tsuccesscreatesuccess-predicate-failure)
+   - [`Ensure<TFailure, TSuccess>(createSuccess, predicate, createFailure)`](#ensuretfailure-tsuccesscreatesuccess-predicate-createfailure)
+   - [`Ensure<TAuxiliary, TFailure, TSuccess>(success, auxiliary, predicate, createFailure)`](#ensuretauxiliary-tfailure-tsuccesssuccess-auxiliary-predicate-createfailure)
+   - [`Ensure<TAuxiliary, TFailure, TSuccess>(success, createAuxiliary, predicate, createFailure)`](#ensuretauxiliary-tfailure-tsuccesssuccess-createauxiliary-predicate-createfailure)
+   - [`Ensure<TAuxiliary, TFailure, TSuccess>(createSuccess, auxiliary, predicate, createFailure)`](#ensuretauxiliary-tfailure-tsuccesscreatesuccess-auxiliary-predicate-createfailure)
+   - [`Ensure<TAuxiliary, TFailure, TSuccess>(createSuccess, createAuxiliary, predicate, createFailure)`](#ensuretauxiliary-tfailure-tsuccesscreatesuccess-createauxiliary-predicate-createfailure)
 2. [Additional resources](#additional-resources)
 
 ### Methods
 
-#### `Catch`
+#### `Fail<TFailure, TSuccess>(failure)`
 
-Creates a new failed result if the value of `createSuccess` throws `TException`; otherwise, creates a new successful result.
+- Declaration:
 
-- `Catch<TException, TSuccess, TFailure>(Func<TSuccess> createSuccess, Func<TException, TFailure> createFailure)`:
+  ```cs
+  public static Result<TFailure, TSuccess> Fail<TFailure, TSuccess>(TFailure failure)
+  ```
 
-  | Generic      | Description                |
+- Description: Creates a new failed result.
+- Generics:
+  | Name       | Description              |
+  |:-----------|:-------------------------|
+  | `TFailure` | Type of possible failure |
+  | `TSuccess` | Type of expected success |
+- Parameters:
+  | Name      | Description          |
+  |:----------|:---------------------|
+  | `failure` | The possible failure |
+
+***[Top](#resultfactory)***
+
+#### `Fail<TFailure, TSuccess>(createFailure)`
+
+- Declaration:
+
+  ```cs
+  public static Result<TFailure, TSuccess> Fail<TFailure, TSuccess>(Func<TFailure> createFailure)
+  ```
+
+- Description: Creates a new failed result.
+- Generics:
+  | Name       | Description              |
+  |:-----------|:-------------------------|
+  | `TFailure` | Type of possible failure |
+  | `TSuccess` | Type of expected success |
+- Parameters:
+  | Name            | Description                  |
+  |:----------------|:-----------------------------|
+  | `createFailure` | Creates the possible failure |
+
+***[Top](#resultfactory)***
+
+#### `Succeed<TFailure, TSuccess>(success)`
+
+- Declaration:
+
+  ```cs
+  public static Result<TFailure, TSuccess> Succeed<TFailure, TSuccess>(TSuccess success)
+  ```
+
+- Description: Creates a new successful result.
+- Generics:
+  | Name       | Description              |
+  |:-----------|:-------------------------|
+  | `TFailure` | Type of possible failure |
+  | `TSuccess` | Type of expected success |
+- Parameters:
+  | Name      | Description          |
+  |:----------|:---------------------|
+  | `success` | The expected success |
+
+***[Top](#resultfactory)***
+
+#### `Succeed<TFailure, TSuccess>(createSuccess)`
+
+- Declaration:
+
+  ```cs
+  public static Result<TFailure, TSuccess> Succeed<TFailure, TSuccess>(Func<TSuccess> createSuccess)
+  ```
+
+- Description: Creates a new successful result.
+- Generics:
+  | Name       | Description              |
+  |:-----------|:-------------------------|
+  | `TFailure` | Type of possible failure |
+  | `TSuccess` | Type of expected success |
+- Parameters:
+  | Name            | Description                  |
+  |:----------------|:-----------------------------|
+  | `createSuccess` | Creates the expected success |
+
+***[Top](#resultfactory)***
+
+#### `Catch<TException, TFailure, TSuccess>(createSuccess, createFailure)`
+
+- Declaration:
+
+  ```cs
+  public static Result<TFailure, TSuccess> Catch<TException, TFailure, TSuccess>(Func<TSuccess> createSuccess, Func<TException, TFailure> createFailure)
+    where TException : Exception
+  ```
+
+- Description:  Creates a new failed result if the value of `createSuccess` throws `TException`; otherwise, creates a new successful result.
+- Generics:
+  | Name         | Description                |
   |:-------------|:---------------------------|
   | `TException` | Type of possible exception |
-  | `TSuccess`   | Type of expected success   |
   | `TFailure`   | Type of possible failure   |
-
-  | Parameter       | Description                  |
+  | `TSuccess`   | Type of expected success   |
+- Parameters:
+  | Name            | Description                  |
   |:----------------|:-----------------------------|
   | `createSuccess` | Creates the expected success |
   | `createFailure` | Creates the possible failure |
 
-***[Top](#static-class-resultfactory)***
+***[Top](#resultfactory)***
 
-[bool]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/bool
+#### `Ensure<TFailure, TSuccess>(success, predicate, failure)`
 
-#### `Ensure`
+- Declaration:
 
-Creates a new failed result if the value of `predicate` is [true][bool]; otherwise, creates a new successful result.
+  ```cs
+  public static Result<TFailure, TSuccess> Ensure<TFailure, TSuccess>(TSuccess success, Func<TSuccess, bool> predicate, TFailure failure)
+  ```
 
-| Generic    | Description              |
-|:-----------|:-------------------------|
-| `TSuccess` | Type of expected success |
-| `TFailure` | Type of possible failure |
-
-- `Ensure<TSuccess, TFailure>(TSuccess success, Func<TSuccess, bool> predicate, TFailure failure)`:
-
-  | Parameter   | Description               |
+- Description: Creates a new failed result if the value of `predicate` is `true`; otherwise, creates a new successful result.
+- Generics:
+  | Name       | Description              |
+  |:-----------|:-------------------------|
+  | `TFailure` | Type of possible failure |
+  | `TSuccess` | Type of expected success |
+- Parameters:
+  | Name        | Description               |
   |:------------|:--------------------------|
   | `success`   | The expected success      |
   | `predicate` | Creates a set of criteria |
   | `failure`   | The possible failure      |
 
-- `Ensure<TSuccess, TFailure>(TSuccess success, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)`:
+***[Top](#resultfactory)***
 
-  | Parameter       | Description                  |
+#### `Ensure<TFailure, TSuccess>(success, predicate, createFailure)`
+
+- Declaration:
+
+  ```cs
+  public static Result<TFailure, TSuccess> Ensure<TFailure, TSuccess>(TSuccess success, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)
+  ```
+
+- Description: Creates a new failed result if the value of `predicate` is `true`; otherwise, creates a new successful result.
+- Generics:
+  | Name       | Description              |
+  |:-----------|:-------------------------|
+  | `TFailure` | Type of possible failure |
+  | `TSuccess` | Type of expected success |
+- Parameters:
+  | Name            | Description                  |
   |:----------------|:-----------------------------|
   | `success`       | The expected success         |
   | `predicate`     | Creates a set of criteria    |
   | `createFailure` | Creates the possible failure |
 
-- `Ensure<TSuccess, TFailure>(Func<TSuccess> createSuccess, Func<TSuccess, bool> predicate, TFailure failure)`:
+***[Top](#resultfactory)***
 
-  | Parameter       | Description                  |
+#### `Ensure<TFailure, TSuccess>(createSuccess, predicate, failure)`
+
+- Declaration:
+
+  ```cs
+  public static Result<TFailure, TSuccess> Ensure<TFailure, TSuccess>(Func<TSuccess> createSuccess, Func<TSuccess, bool> predicate, TFailure failure)
+  ```
+
+- Description: Creates a new failed result if the value of `predicate` is `true`; otherwise, creates a new successful result.
+- Generics:
+  | Name       | Description              |
+  |:-----------|:-------------------------|
+  | `TFailure` | Type of possible failure |
+  | `TSuccess` | Type of expected success |
+- Parameters:
+  | Name            | Description                  |
   |:----------------|:-----------------------------|
   | `createSuccess` | Creates the expected success |
   | `predicate`     | Creates a set of criteria    |
   | `failure`       | The possible failure         |
 
-- `Ensure<TSuccess, TFailure>(Func<TSuccess> createSuccess, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)`:
+***[Top](#resultfactory)***
 
-  | Parameter       | Description                  |
+#### `Ensure<TFailure, TSuccess>(createSuccess, predicate, createFailure)`
+
+- Declaration:
+
+  ```cs
+  public static Result<TFailure, TSuccess> Ensure<TFailure, TSuccess>(Func<TSuccess> createSuccess, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)
+  ```
+
+- Description: Creates a new failed result if the value of `predicate` is `true`; otherwise, creates a new successful result.
+- Generics:
+  | Name       | Description              |
+  |:-----------|:-------------------------|
+  | `TFailure` | Type of possible failure |
+  | `TSuccess` | Type of expected success |
+- Parameters:
+  | Name            | Description                  |
   |:----------------|:-----------------------------|
   | `createSuccess` | Creates the expected success |
   | `predicate`     | Creates a set of criteria    |
   | `createFailure` | Creates the possible failure |
 
-- `Ensure<TAuxiliary, TSuccess, TFailure>(TSuccess success, TAuxiliary auxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)`:
+***[Top](#resultfactory)***
 
-  | Generic      | Description       |
-  |:-------------|:------------------|
-  | `TAuxiliary` | Type of auxiliary |
+#### `Ensure<TAuxiliary, TFailure, TSuccess>(success, auxiliary, predicate, createFailure)`
 
-  | Parameter       | Description                                                              |
+- Declaration:
+
+  ```cs
+  public static Result<TFailure, TSuccess> Ensure<TAuxiliary, TFailure, TSuccess>(TSuccess success, TAuxiliary auxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
+  ```
+
+- Description: Creates a new failed result if the value of `predicate` is `true`; otherwise, creates a new successful result.
+- Generics:
+  | Name         | Description              |
+  |:-------------|:-------------------------|
+  | `TAuxiliary` | Type of auxiliary        |
+  | `TFailure`   | Type of possible failure |
+  | `TSuccess`   | Type of expected success |
+- Parameters:
+  | Name            | Description                                                              |
   |:----------------|:-------------------------------------------------------------------------|
   | `success`       | The expected success                                                     |
   | `auxiliary`     | The auxiliary to use in combination with `predicate` and `createFailure` |
   | `predicate`     | Creates a set of criteria                                                |
   | `createFailure` | Creates the possible failure                                             |
 
-- `Ensure<TAuxiliary, TSuccess, TFailure>(TSuccess success, Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)`:
+***[Top](#resultfactory)***
 
-  | Generic      | Description       |
-  |:-------------|:------------------|
-  | `TAuxiliary` | Type of auxiliary |
+#### `Ensure<TAuxiliary, TFailure, TSuccess>(success, createAuxiliary, predicate, createFailure)`
 
-  | Parameter         | Description                                                                      |
+- Declaration:
+
+  ```cs
+  public static Result<TFailure, TSuccess> Ensure<TAuxiliary, TFailure, TSuccess>(TSuccess success, Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
+  ```
+
+- Description: Creates a new failed result if the value of `predicate` is `true`; otherwise, creates a new successful result.
+- Generics:
+  | Name         | Description              |
+  |:-------------|:-------------------------|
+  | `TAuxiliary` | Type of auxiliary        |
+  | `TFailure`   | Type of possible failure |
+  | `TSuccess`   | Type of expected success |
+- Parameters:
+  | Name              | Description                                                                      |
   |:------------------|:---------------------------------------------------------------------------------|
   | `success`         | The expected success                                                             |
   | `createAuxiliary` | Creates the auxiliary to use in combination with `predicate` and `createFailure` |
   | `predicate`       | Creates a set of criteria                                                        |
   | `createFailure`   | Creates the possible failure                                                     |
 
-- `Ensure<TAuxiliary, TSuccess, TFailure>(Func<TSuccess> createSuccess, TAuxiliary auxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)`:
+***[Top](#resultfactory)***
 
-  | Generic      | Description       |
-  |:-------------|:------------------|
-  | `TAuxiliary` | Type of auxiliary |
+#### `Ensure<TAuxiliary, TFailure, TSuccess>(createSuccess, auxiliary, predicate, createFailure)`
 
-  | Parameter       | Description                                                              |
+- Declaration:
+
+  ```cs
+  public static Result<TFailure, TSuccess> Ensure<TAuxiliary, TFailure, TSuccess>(Func<TSuccess> createSuccess, TAuxiliary auxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
+  ```
+
+- Description: Creates a new failed result if the value of `predicate` is `true`; otherwise, creates a new successful result.
+- Generics:
+  | Name         | Description              |
+  |:-------------|:-------------------------|
+  | `TAuxiliary` | Type of auxiliary        |
+  | `TFailure`   | Type of possible failure |
+  | `TSuccess`   | Type of expected success |
+- Parameters:
+  | Name            | Description                                                              |
   |:----------------|:-------------------------------------------------------------------------|
   | `createSuccess` | Creates the expected success                                             |
   | `auxiliary`     | The auxiliary to use in combination with `predicate` and `createFailure` |
   | `predicate`     | Creates a set of criteria                                                |
   | `createFailure` | Creates the possible failure                                             |
 
-- `Ensure<TAuxiliary, TSuccess, TFailure>(Func<TSuccess> createSuccess, Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)`:
+***[Top](#resultfactory)***
 
-  | Generic      | Description       |
-  |:-------------|:------------------|
-  | `TAuxiliary` | Type of auxiliary |
+#### `Ensure<TAuxiliary, TFailure, TSuccess>(createSuccess, createAuxiliary, predicate, createFailure)`
 
-  | Parameter         | Description                                                                      |
+- Declaration:
+
+  ```cs
+  public static Result<TFailure, TSuccess> Ensure<TAuxiliary, TFailure, TSuccess>(Func<TSuccess> createSuccess, Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
+  ```
+
+- Description: Creates a new failed result if the value of `predicate` is `true`; otherwise, creates a new successful result.
+- Generics:
+  | Name         | Description              |
+  |:-------------|:-------------------------|
+  | `TAuxiliary` | Type of auxiliary        |
+  | `TFailure`   | Type of possible failure |
+  | `TSuccess`   | Type of expected success |
+- Parameters:
+  | Name              | Description                                                                      |
   |:------------------|:---------------------------------------------------------------------------------|
   | `createSuccess`   | Creates the expected success                                                     |
   | `createAuxiliary` | Creates the auxiliary to use in combination with `predicate` and `createFailure` |
   | `predicate`       | Creates a set of criteria                                                        |
   | `createFailure`   | Creates the possible failure                                                     |
 
-***[Top](#static-class-resultfactory)***
-
-#### `Succeed`
-
-Creates a new successful result.
-
-| Generic    | Description              |
-|:-----------|:-------------------------|
-| `TSuccess` | Type of expected success |
-| `TFailure` | Type of possible failure |
-
-- `Succeed<TSuccess, TFailure>(TSuccess success)`:
-
-  | Parameter | Description          |
-  |:----------|:---------------------|
-  | `success` | The expected success |
-
-- `Succeed<TSuccess, TFailure>(Func<TSuccess> createSuccess)`:
-
-  | Parameter       | Description                  |
-  |:----------------|:-----------------------------|
-  | `createSuccess` | Creates the expected success |
-
-***[Top](#static-class-resultfactory)***
-
-#### `Fail`
-
-Creates a new failed result.
-
-| Generic    | Description              |
-|:-----------|:-------------------------|
-| `TSuccess` | Type of expected success |
-| `TFailure` | Type of possible failure |
-
-- `Fail<TSuccess, TFailure>(TFailure failure)`:
-
-  | Parameter | Description          |
-  |:----------|:---------------------|
-  | `failure` | The possible failure |
-
-- `Fail<TSuccess, TFailure>(Func<TFailure> createFailure)`:
-
-  | Parameter       | Description                  |
-  |:----------------|:-----------------------------|
-  | `createFailure` | Creates the possible failure |
-
-***[Top](#static-class-resultfactory)***
+***[Top](#resultfactory)***
 
 ### Additional resources
 
-- [`Result<TSuccess, TFailure>`](./result.md): Type that encapsulates both the expected success and the possible failure of a given action.
-- [License](../../license).
-- [Security policy](../../security.md).
-- [Code of conduct](../../code-of-conduct.md).
-- [Contributing guidelines](../../contributing.md).
+- [`Result<TFailure, TSuccess>`](./result.md): Type intended to manage both the possible failure and the expected success of a given action.
+- [License](../../license)
+- [Security policy](../../security.md)
+- [Code of conduct](../../code-of-conduct.md)
+- [Contributing guidelines](../../contributing.md)
 
-***[Top](#static-class-resultfactory)***
+***[Top](#resultfactory)***

--- a/documentation/monads/result.md
+++ b/documentation/monads/result.md
@@ -1,232 +1,373 @@
-# `sealed class Result<TSuccess, TFailure>`
+# `Result<TFailure, TSuccess>`
 
 ***[home](../../readme.md) / monads /***
 
-Type that encapsulates both the expected success and the possible failure of a given action.
+```cs
+public sealed class Result<TFailure, TSuccess>
+ ```
 
-| Generic    | Description              |
-|:-----------|:-------------------------|
-| `TSuccess` | Type of expected success |
-| `TFailure` | Type of possible failure |
+Type intended to manage both the possible failure and the expected success of a given action.
 
 ## Table of contents
 
-1. [Constructors](#constructors)
+1. [Generics](#generics)
+   - [`TFailure`](#tfailure)
+   - [`TSuccess`](#tsuccess)
 2. [Properties](#properties)
-3. [Implicit operators](#implicit-operators)
-4. [Methods](#methods)
-   - [`Ensure`](#ensure)
-   - [`DoOnSuccess`](#doonsuccess)
-   - [`DoOnFailure`](#doonfailure)
-   - [`Map`](#map)
-   - [`Bind`](#bind)
-   - [`Reduce`](#reduce)
-5. [Additional resources](#additional-resources)
+   - [`IsFailed`](#isfailed)
+   - [`Failure`](#failure)
+   - [`IsSuccessful`](#issuccessful)
+   - [`Success`](#success)
+3. [Constructors](#constructors)
+    - [`Result(failure)`](#resultfailure)
+    - [`Result(success)`](#resultsuccess)
+4. [Implicit operators](#implicit-operators)
+   - [`Result<TSuccess, TFailure>(failure)`](#resulttfailure-tsuccessfailure)
+   - [`Result<TSuccess, TFailure>(success)`](#resulttfailure-tsuccesssuccess)
+5. [Methods](#methods)
+   - [`Ensure(predicate, failure)`](#ensurepredicate-failure)
+   - [`Ensure(predicate, createFailure)`](#ensurepredicate-createfailure)
+   - [`Ensure<TAuxiliary>(auxiliary, predicate, createFailure)`](#ensuretauxiliaryauxiliary-predicate-createfailure)
+   - [`Ensure<TAuxiliary>(createAuxiliary, predicate, createFailure)`](#ensuretauxiliarycreateauxiliary-predicate-createfailure)
+   - [`DoOnFailure(execute)`](#doonfailureexecute)
+   - [`DoOnSuccess(execute)`](#doonsuccessexecute)
+   - [`Map<TSuccessToMap>(successToMap)`](#maptsuccesstomapsuccesstomap)
+   - [`Map<TSuccessToMap>(createSuccessToMap)`](#maptsuccesstomapcreatesuccesstomap)
+   - [`Bind<TSuccessToBind>(createResultToBind)`](#bindtsuccesstobindcreateresulttobind)
+   - [`Reduce<TReducer>(reduceFailure, reduceSuccess)`](#reducetreducerreducefailure-reducesuccess)
+6. [Additional resources](#additional-resources)
 
-### Constructors
+### Generics
 
-- `Result(TSuccess success)`:
+#### `TFailure`
 
-  Creates a new successful result.
+Type of possible failure.
 
-  | Parameter | Description          |
-  |:----------|:---------------------|
-  | `success` | The expected success |
+***[Top](#resulttfailure-tsuccess)***
 
-- `Result(TFailure failure)`:
+#### `TSuccess`
 
-  Creates a new failed result.
+Type of expected success.
 
-  | Parameter | Description          |
-  |:----------|:---------------------|
-  | `failure` | The possible failure |
-
-***[Top](#sealed-class-resulttsuccess-tfailure)***
-
-[bool]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/bool
+***[Top](#resulttfailure-tsuccess)***
 
 ### Properties
 
-| Member         | Type           | Description                                |
-|:---------------|:---------------|:-------------------------------------------|
-| `IsSuccessful` | [`bool`][bool] | Indicates whether the status is successful |
-| `Success`      | `TSuccess`     | The expected success                       |
-| `IsFailed`     | [`bool`][bool] | Indicates whether the status is failed     |
-| `Failure`      | `TFailure`     | The possible failure                       |
+#### `IsFailed`
 
-***[Top](#sealed-class-resulttsuccess-tfailure)***
+- Declaration
 
-### Implicit operators
+  ```cs
+  public bool IsFailed { get; }
+  ```
 
-- `Result<TSuccess, TFailure>(TSuccess success)`:
+- Description: Indicates whether the status is failed.
 
-  Creates a new successful result.
+***[Top](#resulttfailure-tsuccess)***
 
-  | Parameter | Description          |
-  |:----------|:---------------------|
-  | `success` | The expected success |
+#### `Failure`
 
-- `Result<TSuccess, TFailure>(TFailure failure)`:
+- Declaration
 
-  Creates a new failed result.
+  ```cs
+  public TFailure Failure { get; }
+  ```
 
-  | Parameter | Description          |
+- Description: The possible failure.
+
+***[Top](#resulttfailure-tsuccess)***
+
+#### `IsSuccessful`
+
+- Declaration
+
+  ```cs
+  public bool IsSuccessful { get; }
+  ```
+
+- Description: Indicates whether the status is successful.
+
+***[Top](#resulttfailure-tsuccess)***
+
+#### `Success`
+
+- Declaration
+
+  ```cs
+  public TSuccess Success { get; }
+  ```
+
+- Description: The expected success.
+
+***[Top](#resulttfailure-tsuccess)***
+
+### Constructors
+
+#### `Result(failure)`
+
+- Declaration:
+
+  ```cs
+  public Result(TFailure failure)
+  ```
+
+- Description: Creates a new failed result.
+- Parameters:
+  | Name      | Description          |
   |:----------|:---------------------|
   | `failure` | The possible failure |
 
-***[Top](#sealed-class-resulttsuccess-tfailure)***
+***[Top](#resulttfailure-tsuccess)***
+
+#### `Result(success)`
+
+- Declaration:
+
+  ```cs
+  public Result(TSuccess success)
+  ```
+
+- Description: Creates a new successful result.
+- Parameters:
+  | Name      | Description          |
+  |:----------|:---------------------|
+  | `success` | The expected success |
+
+***[Top](#resulttfailure-tsuccess)***
+
+### Implicit operators
+
+#### `Result<TFailure, TSuccess>(failure)`
+
+- Declaration:
+
+  ```cs
+  public static implicit operator Result<TFailure, TSuccess>(TFailure failure)
+  ```
+
+- Description: Creates a new failed result.
+- Parameters:
+  | Name      | Description          |
+  |:----------|:---------------------|
+  | `failure` | The possible failure |
+
+***[Top](#resulttfailure-tsuccess)***
+
+#### `Result<TFailure, TSuccess>(success)`
+
+- Declaration:
+
+  ```cs
+  public static implicit operator Result<TFailure, TSuccess>(TSuccess success)
+  ```
+
+- Description: Creates a new successful result.
+- Parameters:
+  | Name      | Description          |
+  |:----------|:---------------------|
+  | `success` | The expected success |
+
+***[Top](#resulttfailure-tsuccess)***
 
 ### Methods
 
-#### `Ensure`
+#### `Ensure(predicate, failure)`
 
-Creates a new failed result if the value of `predicate` is [`true`][bool]; otherwise, returns the previous result.
+- Declaration:
 
-- `Ensure(Func<TSuccess, bool> predicate, TFailure failure)`:
+  ```cs
+  public Result<TFailure, TSuccess> Ensure(Func<TSuccess, bool> predicate, TFailure failure)
+  ```
 
-  | Parameter   | Description               |
+- Description: Creates a new failed result if the value of `predicate` is `true`; otherwise, returns the previous result.
+- Parameters:
+  | Name        | Description               |
   |:------------|:--------------------------|
   | `predicate` | Creates a set of criteria |
   | `failure`   | The possible failure      |
 
-  Returns `Result<TSuccess, TFailure>`.
+***[Top](#resulttfailure-tsuccess)***
 
-- `Ensure(Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)`:
+#### `Ensure(predicate, createFailure)`
 
-  | Parameter       | Description                  |
+- Declaration:
+
+  ```cs
+  public Result<TFailure, TSuccess> Ensure(Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> createFailure)
+  ```
+
+- Description: Creates a new failed result if the value of `predicate` is `true`; otherwise, returns the previous result.
+- Parameters:
+  | Name            | Description                  |
   |:----------------|:-----------------------------|
   | `predicate`     | Creates a set of criteria    |
   | `createFailure` | Creates the possible failure |
 
-  Returns `Result<TSuccess, TFailure>`.
+***[Top](#resulttfailure-tsuccess)***
 
-- `Ensure<TAuxiliary>(TAuxiliary auxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)`:
+#### `Ensure<TAuxiliary>(auxiliary, predicate, createFailure)`
 
-  | Generic      | Description       |
+- Declaration:
+
+  ```cs
+  public Result<TFailure, TSuccess> Ensure<TAuxiliary>(TAuxiliary auxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
+  ```
+
+- Description: Creates a new failed result if the value of `predicate` is `true`; otherwise, returns the previous result.
+- Generics:
+  | Name         | Description       |
   |:-------------|:------------------|
   | `TAuxiliary` | Type of auxiliary |
-
-  | Parameter       | Description                                                              |
+- Parameters:
+  | Name            | Description                                                              |
   |:----------------|:-------------------------------------------------------------------------|
   | `auxiliary`     | The auxiliary to use in combination with `predicate` and `createFailure` |
   | `predicate`     | Creates a set of criteria                                                |
   | `createFailure` | Creates the possible failure                                             |
 
-  Returns `Result<TSuccess, TFailure>`.
+***[Top](#resulttfailure-tsuccess)***
 
-- `Ensure<TAuxiliary>(Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)`:
+#### `Ensure<TAuxiliary>(createAuxiliary, predicate, createFailure)`
 
+- Declaration:
+
+  ```cs
+  public Result<TFailure, TSuccess> Ensure<TAuxiliary>(Func<TAuxiliary> createAuxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
+  ```
+
+- Description: Creates a new failed result if the value of `predicate` is `true`; otherwise, returns the previous result.
+- Generics:
   | Generic      | Description       |
   |:-------------|:------------------|
   | `TAuxiliary` | Type of auxiliary |
-
-  | Parameter         | Description                                                                      |
+- Parameters:
+  | Name              | Description                                                                      |
   |:------------------|:---------------------------------------------------------------------------------|
   | `createAuxiliary` | Creates the auxiliary to use in combination with `predicate` and `createFailure` |
   | `predicate`       | Creates a set of criteria                                                        |
   | `createFailure`   | Creates the possible failure                                                     |
 
-  Returns `Result<TSuccess, TFailure>`.
+***[Top](#resulttfailure-tsuccess)***
 
-***[Top](#sealed-class-resulttsuccess-tfailure)***
+#### `DoOnFailure(execute)`
 
-#### `DoOnSuccess`
+- Declaration:
 
-Executes an action if the previous result is successful.
+  ```cs
+  public Result<TFailure, TSuccess> DoOnFailure(Action<TFailure> execute)
+  ```
 
-- `DoOnSuccess(Action<TSuccess> execute)`:
-
-  | Parameter | Description           |
+- Description: Executes an action if the previous result is failed.
+- Parameters:
+  | Name      | Description           |
   |:----------|:----------------------|
   | `execute` | The action to execute |
 
-  Returns the previous result.
+***[Top](#resulttfailure-tsuccess)***
 
-***[Top](#sealed-class-resulttsuccess-tfailure)***
+#### `DoOnSuccess(execute)`
 
-#### `DoOnFailure`
+- Declaration:
 
-Executes an action if the previous result is failed.
+  ```cs
+  public Result<TFailure, TSuccess> DoOnSuccess(Action<TSuccess> execute)
+  ```
 
-- `DoOnFailure(Action<TFailure> execute)`:
-
-  | Parameter | Description           |
+- Description: Executes an action if the previous result is successful.
+- Parameters:
+  | Name      | Description           |
   |:----------|:----------------------|
   | `execute` | The action to execute |
 
-  Returns the previous result.
+***[Top](#resulttfailure-tsuccess)***
 
-***[Top](#sealed-class-resulttsuccess-tfailure)***
+#### `Map<TSuccessToMap>(successToMap)`
 
-#### `Map`
+- Declaration:
 
-Creates a new result with the same or different type of expected success.
+  ```cs
+  public Result<TFailure, TSuccessToMap> Map<TSuccessToMap>(TSuccessToMap successToMap)
+  ```
 
-| Generic         | Description                     |
-|:----------------|:--------------------------------|
-| `TSuccessToMap` | Type of expected success to map |
-
-- `Map<TSuccessToMap>(TSuccessToMap successToMap)`:
-
-  | Parameter      | Description                 |
+- Description: Creates a new result with the same or different type of expected success.
+- Generics:
+  | Name            | Description                     |
+  |:----------------|:--------------------------------|
+  | `TSuccessToMap` | Type of expected success to map |
+- Parameters:
+  | Name           | Description                 |
   |:---------------|:----------------------------|
   | `successToMap` | The expected success to map |
 
-  Returns `Result<TSuccessToMap, TFailure>`.
+***[Top](#resulttfailure-tsuccess)***
 
-- `Map<TSuccessToMap>(Func<TSuccess, TSuccessToMap> createSuccessToMap)`:
+#### `Map<TSuccessToMap>(createSuccessToMap)`
 
-  | Parameter            | Description                         |
+- Declaration:
+
+  ```cs
+  public Result<TFailure, TSuccessToMap> Map<TSuccessToMap>(Func<TSuccess, TSuccessToMap> createSuccessToMap)
+  ```
+
+- Description: Creates a new result with the same or different type of expected success.
+- Generics:
+  | Name            | Description                     |
+  |:----------------|:--------------------------------|
+  | `TSuccessToMap` | Type of expected success to map |
+- Parameters:
+  | Name                 | Description                         |
   |:---------------------|:------------------------------------|
   | `createSuccessToMap` | Creates the expected success to map |
 
-  Returns `Result<TSuccessToMap, TFailure>`.
+***[Top](#resulttfailure-tsuccess)***
 
-***[Top](#sealed-class-resulttsuccess-tfailure)***
+#### `Bind<TSuccessToBind>(createResultToBind)`
 
-#### `Bind`
+- Declaration:
 
-Creates a new result in combination with another result with the same or different type of expected success.
+  ```cs
+  public Result<TFailure, TSuccessToBind> Bind<TSuccessToBind>(Func<TSuccess, Result<TFailure, TSuccessToBind>> createResultToBind)
+  ```
 
-| Generic          | Description                      |
-|:-----------------|:---------------------------------|
-| `TSuccessToBind` | Type of expected success to bind |
-
-- `Bind<TSuccessToBind>(Func<TSuccess, Result<TSuccessToBind, TFailure>> createResultToBind)`:
-
-  | Parameter            | Description                  |
+- Description: Creates a new result in combination with another result with the same or different type of expected success.
+- Generics:
+  | Name             | Description                      |
+  |:-----------------|:---------------------------------|
+  | `TSuccessToBind` | Type of expected success to bind |
+- Parameters:
+  | Name                 | Description                  |
   |:---------------------|:-----------------------------|
   | `createResultToBind` | Creates a new result to bind |
 
-  Returns `Result<TSuccessToBind, TFailure>`.
+***[Top](#resulttfailure-tsuccess)***
 
-***[Top](#sealed-class-resulttsuccess-tfailure)***
+#### `Reduce<TReducer>(reduceFailure, reduceSuccess)`
 
-#### `Reduce`
+- Declaration:
 
-Creates a new reduced failure if the result is failed; otherwise, creates a new reduced success.
+  ```cs
+  public TReducer Reduce<TReducer>(Func<TFailure, TReducer> reduceFailure, Func<TSuccess, TReducer> reduceSuccess)
+  ```
 
-| Generic    | Description     |
-|:-----------|:----------------|
-| `TReducer` | Type of reducer |
+- Description: Creates a new reduced failure if the previous result is failed; otherwise, creates a new reduced success.
+- Generics:
+  | Name       | Description     |
+  |:-----------|:----------------|
+  | `TReducer` | Type of reducer |
+- Parameters:
+  | Name            | Description                          |
+  |:----------------|:-------------------------------------|
+  | `reduceFailure` | Creates the possible reduced failure |
+  | `reduceSuccess` | Creates the expected reduced success |
 
-- `Reduce<TReducer>(Func<TSuccess, TReducer> createReducedSuccess, Func<TFailure, TReducer> createReducedFailure)`:
-
-  | Parameter              | Description                          |
-  |:-----------------------|:-------------------------------------|
-  | `createReducedSuccess` | Creates the expected reduced success |
-  | `createReducedFailure` | Creates the possible reduced failure |
-
-  Returns `TReducer`.
-
-***[Top](#sealed-class-resulttsuccess-tfailure)***
+***[Top](#resulttfailure-tsuccess)***
 
 ### Additional resources
 
-- [`ResultFactory`](./result-factory.md): Type that exposes a set of ways to initialize `Result<TSuccess, TFailure>`.
-- [License](../../license).
-- [Security policy](../../security.md).
-- [Code of conduct](../../code-of-conduct.md).
-- [Contributing guidelines](../../contributing.md).
+- [`ResultFactory`](./result-factory.md): Type intended to expose a set of ways to initialize [`Result<TFailure, TSuccess>`](#resulttfailure-tsuccess).
+- [License](../../license)
+- [Security policy](../../security.md)
+- [Code of conduct](../../code-of-conduct.md)
+- [Contributing guidelines](../../contributing.md)
 
-***[Top](#sealed-class-resulttsuccess-tfailure)***
+***[Top](#resulttfailure-tsuccess)***

--- a/readme.md
+++ b/readme.md
@@ -12,9 +12,6 @@
 [![Library](https://img.shields.io/github/actions/workflow/status/daht-x/sagitta-core/library.yaml?style=for-the-badge&logo=github-actions&logoColor=FFFFFF&label=Library&labelColor=000000)](https://github.com/daht-x/sagitta-core/actions/workflows/library.yaml)
 [![Markdown](https://img.shields.io/github/actions/workflow/status/daht-x/sagitta-core/markdown.yaml?style=for-the-badge&logo=github-actions&logoColor=FFFFFF&label=Markdown&labelColor=000000)](https://github.com/daht-x/sagitta-core/actions/workflows/markdown.yaml)
 
-[![LinkedIn](https://img.shields.io/badge/LinkedIn-000000?style=for-the-badge&logo=linkedin&logoColor=FFFFFF)](https://www.linkedin.com/in/daht-x)
-[![X (Twitter)](https://img.shields.io/badge/X%20(Twitter)-000000?style=for-the-badge&logo=x&logoColor=FFFFFF)](https://twitter.com/_daht_x)
-
 ## Table of contents
 
 1. [Installation](#installation)
@@ -24,12 +21,13 @@
 4. [Security policy](#security-policy)
 5. [Code of conduct](#code-of-conduct)
 6. [Contributing guidelines](#contributing-guidelines)
+7. [Contact](#contact)
 
 ### Installation
 
 ***For information on all available versions, please see the [NuGet][nuget-package-registry] or [GitHub](https://github.com/daht-x/sagitta-core/pkgs/nuget/Daht.Sagitta.Core) package registry***
 
-Please select the installation method that best suits your workflow:
+Please choose the installation method that best suits your workflow:
 
 - [.NET command-line interface (CLI)](https://learn.microsoft.com/en-us/dotnet/core/tools):
 
@@ -90,10 +88,10 @@ The monads represent a set of structures that provide ways to manage the state o
 [result]: https://github.com/daht-x/sagitta-core/blob/main/documentation/monads/result.md
 [result-factory]: https://github.com/daht-x/sagitta-core/blob/main/documentation/monads/result-factory.md
 
-| Type                                   | Description                                                                                 |
-|:---------------------------------------|:--------------------------------------------------------------------------------------------|
-| [`Result<TSuccess, TFailure>`][result] | Type that encapsulates both the expected success and the possible failure of a given action |
-| [`ResultFactory`][result-factory]      | Type that exposes a set of ways to initialize [`Result<TSuccess, TFailure>`][result]        |
+| Type                                   | Description                                                                                  |
+|:---------------------------------------|:---------------------------------------------------------------------------------------------|
+| [`Result<TFailure, TSuccess>`][result] | Type intended to manage both the possible failure and the expected success of a given action |
+| [`ResultFactory`][result-factory]      | Type intended to expose a set of ways to initialize [`Result<TFailure, TSuccess>`][result]   |
 
 ***[Top](#sagitta---core)***
 
@@ -120,3 +118,8 @@ Please read and follow our [code of conduct](https://github.com/daht-x/sagitta-c
 Please read and follow our [contributing guidelines](https://github.com/daht-x/sagitta-core/blob/main/contributing.md).
 
 ***[Top](#sagitta---core)***
+
+### Contact
+
+- [LinkedIn](https://www.linkedin.com/in/daht-x)
+- [X (Twitter)](https://twitter.com/_daht_x)

--- a/security.md
+++ b/security.md
@@ -36,8 +36,8 @@ Please send a direct message (DM) to [@_daht_x](https://twitter.com/_daht_x) and
 
 ### Additional resources
 
-- [License](./license).
-- [Code of conduct](./code-of-conduct.md).
-- [Contributing guidelines](./contributing.md).
+- [License](./license)
+- [Code of conduct](./code-of-conduct.md)
+- [Contributing guidelines](./contributing.md)
 
 ***[Top](#security-policy)***


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta-core/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta-core/blob/main/contributing.md).

## Table of contents

1. [Tickets](#tickets)
2. [Description](#description)
3. [Additional information](#additional-information)

### Tickets

<!-- Provide related issue tickets | Optional -->

Undefined.

***[Top](#pull-request)***

### Description

<!-- Provide a concise and clear description | Required -->

The information provided by the API was synchronized and structured based on the compatibility changes integrated in pull requests #257 and #259.

***[Top](#pull-request)***

### Additional information

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

Undefined.

***[Top](#pull-request)***
