### PR TITLE
refactor(`Result`): avoid building new instances outside the proposed context

### DIFF
--- a/source/Monads/Result.cs
+++ b/source/Monads/Result.cs
@@ -58,9 +58,15 @@ public sealed class Result<TFailure, TSuccess>
 	/// <param name="failure">The possible failure.</param>
 	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
 	public Result<TFailure, TSuccess> Ensure(Func<TSuccess, bool> predicate, TFailure failure)
-		=> IsFailed
-			? this
-			: ResultFactory.Ensure(Success, predicate, failure);
+	{
+		if (IsFailed)
+		{
+			return this;
+		}
+		return predicate(Success)
+			? new(failure)
+			: this;
+	}
 
 	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
 	/// <param name="createAuxiliary">Creates the auxiliary to use in combination with <paramref name="predicate" /> and <paramref name="createFailure" />.</param>
@@ -78,9 +84,15 @@ public sealed class Result<TFailure, TSuccess>
 	/// <typeparam name="TAuxiliary">Type of auxiliary.</typeparam>
 	/// <returns>A new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, the previous result.</returns>
 	public Result<TFailure, TSuccess> Ensure<TAuxiliary>(TAuxiliary auxiliary, Func<TSuccess, TAuxiliary, bool> predicate, Func<TSuccess, TAuxiliary, TFailure> createFailure)
-		=> IsFailed
-			? this
-			: ResultFactory.Ensure(Success, auxiliary, predicate, createFailure);
+	{
+		if (IsFailed)
+		{
+			return this;
+		}
+		return predicate(Success, auxiliary)
+			? new(createFailure(Success, auxiliary))
+			: this;
+	}
 
 	/// <summary>Executes an action if the previous result is failed.</summary>
 	/// <param name="execute">The action to execute.</param>


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta-core/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta-core/blob/main/contributing.md).

## Table of contents

1. [Tickets](#tickets)
2. [Description](#description)
3. [Additional information](#additional-information)

### Tickets

<!-- Provide related issue tickets | Optional -->

Undefined.

***[Top](#pull-request)***

### Description

<!-- Provide a concise and clear description | Required -->

The generation of new success results for each of the `Ensure` method overloads was replaced by the return of the same object ([`this`](https://learn.microsoft.com/es-es/dotnet/csharp/language-reference/keywords/this)).

***[Top](#pull-request)***

### Additional information

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

Undefined.

***[Top](#pull-request)***
