### PR TITLE
style: fix naming style from `uppercase` to `lowercase`

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -12,7 +12,7 @@ const defaultMinimumLength = 0;
 enum NamingStyle {
 	LowerCase = "lower-case"
 }
-const SIGNATURE_LABEL = "Signed-off-by:";
+const signatureLabel = "Signed-off-by:";
 const rootConfiguration: UserConfig = {
 	rules: {
 		"body-full-stop": [RuleConfigSeverity.Error, RuleCompliance.Always, fullStop],
@@ -49,8 +49,8 @@ const rootConfiguration: UserConfig = {
 		"type-empty": [RuleConfigSeverity.Error, RuleCompliance.Never],
 		"type-max-length": [RuleConfigSeverity.Error, RuleCompliance.Always, defaultMaximumLength],
 		"type-min-length": [RuleConfigSeverity.Error, RuleCompliance.Always, defaultMinimumLength],
-		"signed-off-by": [RuleConfigSeverity.Warning, RuleCompliance.Always, SIGNATURE_LABEL],
-		"trailer-exists": [RuleConfigSeverity.Warning, RuleCompliance.Always, SIGNATURE_LABEL]
+		"signed-off-by": [RuleConfigSeverity.Warning, RuleCompliance.Always, signatureLabel],
+		"trailer-exists": [RuleConfigSeverity.Warning, RuleCompliance.Always, signatureLabel]
 	}
 };
 


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta-core/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta-core/blob/main/contributing.md).

## Table of contents

1. [Tickets](#tickets)
2. [Description](#description)
3. [Additional information](#additional-information)

### Tickets

<!-- Provide related issue tickets | Optional -->

Undefined.

***[Top](#pull-request)***

### Description

<!-- Provide a concise and clear description | Required -->

The `SignatureLabel` variable and its references have changed their naming style from `uppercase` to `lowercase` to maintain the consistency with the pre-existing variables of the configuration file.

***[Top](#pull-request)***

### Additional information

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

Undefined.

***[Top](#pull-request)***
