### PR TITLE
build: remove pre-load condition for the `SonarAnalyzer.CSharp` package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,6 @@
 		<UseArtifactsOutput>true</UseArtifactsOutput>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="SonarAnalyzer.CSharp" Condition="'$(MSBuildProjectExtension)' == '.csproj'" />
+		<PackageReference Include="SonarAnalyzer.CSharp" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta-core/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta-core/blob/main/contributing.md).

## Table of contents

1. [Tickets](#tickets)
2. [Description](#description)
3. [Additional information](#additional-information)

### Tickets

<!-- Provide related issue tickets | Optional -->

Undefined.

***[Top](#pull-request)***

### Description

<!-- Provide a concise and clear description | Required -->

The only .NET language used so far to write the package is C# and therefore, it is not necessary to set a pre-load condition of the [SonarAnalyzer.CSharp](https://www.nuget.org/packages/SonarAnalyzer.CSharp/) package for files with the `.csproj` extension (C# projects).

***[Top](#pull-request)***

### Additional information

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

Undefined.

***[Top](#pull-request)***
