### PR TITLE
feature(`ValueResult`): expose `IsInitialized` as a public property

### DIFF
--- a/libraries/core/source/Monads/Result.cs
+++ b/libraries/core/source/Monads/Result.cs
@@ -12,7 +12,7 @@ namespace Daht.Sagitta.Core.Monads;
 [SuppressMessage(DesignAnalysisCategory.Name, DesignAnalysisCategory.Rules.ValidateArgumentsOfPublicMethods)]
 public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSuccess>>
 {
-	/// <summary>Indicates whether the status is failed.</summary>
+	/// <summary>Indicates whether the state is failed.</summary>
 	[MemberNotNullWhen(true, nameof(failure))]
 	[MemberNotNullWhen(false, nameof(success))]
 	public bool IsFailed { get; }
@@ -27,7 +27,7 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 			? throw new InvalidOperationException(ResultExceptionMessages.AccessToFailureWhenSuccessful)
 			: this.failure;
 
-	/// <summary>Indicates whether the status is successful.</summary>
+	/// <summary>Indicates whether the state is successful.</summary>
 	[MemberNotNullWhen(false, nameof(failure))]
 	[MemberNotNullWhen(true, nameof(success))]
 	public bool IsSuccessful
@@ -73,19 +73,19 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 	public static bool operator ==(Result<TFailure, TSuccess>? left, Result<TFailure, TSuccess>? right)
 		=> (left is null && right is null) || (left is not null && left.Equals(right));
 
-	/// <summary>Indicates whether the status is failed.</summary>
+	/// <summary>Indicates whether the state is failed.</summary>
 	/// <param name="result">The current result.</param>
 	/// <returns><see langword="true" /> if the current result is failed; otherwise, <see langword="false" />.</returns>
 	public static bool operator false(Result<TFailure, TSuccess> result)
 		=> result.IsFailed;
 
-	/// <summary>Indicates whether the status is successful.</summary>
+	/// <summary>Indicates whether the state is successful.</summary>
 	/// <param name="result">The current result.</param>
 	/// <returns><see langword="true" /> if the current result is successful; otherwise, <see langword="false" />.</returns>
 	public static bool operator true(Result<TFailure, TSuccess> result)
 		=> result.IsSuccessful;
 
-	/// <summary>Indicates whether the status is failed.</summary>
+	/// <summary>Indicates whether the state is failed.</summary>
 	/// <param name="result">The current result.</param>
 	/// <returns><see langword="true" /> if the current result is failed; otherwise, <see langword="false" />.</returns>
 	public static bool operator !(Result<TFailure, TSuccess> result)
@@ -125,7 +125,7 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 		=> new(success);
 
 	/// <summary>Deconstructs the root state of the result.</summary>
-	/// <param name="isFailed">Indicates whether the status is failed.</param>
+	/// <param name="isFailed">Indicates whether the state is failed.</param>
 	/// <param name="failure">The possible failure.</param>
 	/// <param name="success">The expected success.</param>
 	public void Deconstruct(out bool isFailed, out TFailure? failure, out TSuccess? success)

--- a/libraries/core/tests/unit/Monads/Asserters/ValueResultAsserter.cs
+++ b/libraries/core/tests/unit/Monads/Asserters/ValueResultAsserter.cs
@@ -7,13 +7,14 @@ namespace Daht.Sagitta.Core.UnitTests.Monads.Asserters;
 
 internal static class ValueResultAsserter
 {
-	internal static void IsDefault(Action execute)
+	internal static void CatchInvalidOperationException(Action execute)
 		=> Assert.Throws<InvalidOperationException>(execute);
 
 	internal static void IsFailed<TFailure, TSuccess>(TFailure expected, ValueResult<TFailure, TSuccess> actual)
 		where TFailure : struct, Enum
 		where TSuccess : struct
 	{
+		Assert.True(actual.IsInitialized);
 		Assert.True(actual.IsFailed);
 		Assert.Equal(expected, actual.Failure);
 		_ = Assert.Throws<InvalidOperationException>(() => actual.Success);
@@ -23,6 +24,7 @@ internal static class ValueResultAsserter
 		where TFailure : struct, Enum
 		where TSuccess : struct
 	{
+		Assert.True(actual.IsInitialized);
 		Assert.False(actual.IsFailed);
 		_ = Assert.Throws<InvalidOperationException>(() => actual.Failure);
 		Assert.Equal(expected, actual.Success);

--- a/libraries/core/tests/unit/Monads/ValueResultTest.cs
+++ b/libraries/core/tests/unit/Monads/ValueResultTest.cs
@@ -324,7 +324,7 @@ public sealed class ValueResultTest
 	[Fact]
 	[Trait(@base, memberDeconstruct)]
 	public void Deconstruct_DefaultResult_InvalidOperationException()
-		=> ValueResultAsserter.IsDefault(static () => (_, _, _) = ValueResultMother.GetDefault());
+		=> ValueResultAsserter.CatchInvalidOperationException(static () => (_, _, _) = ValueResultMother.GetDefault());
 
 	[Fact]
 	[Trait(@base, memberDeconstruct)]
@@ -427,7 +427,7 @@ public sealed class ValueResultTest
 	public void Discard_Default_InvalidOperationException()
 	{
 		ValueResult<Failure, Unit> actual = default;
-		ValueResultAsserter.IsDefault(() => actual.Discard());
+		ValueResultAsserter.CatchInvalidOperationException(() => actual.Discard());
 	}
 
 	[Fact]


### PR DESCRIPTION
# Pull request

## Table of contents

1. [Description](#description)

### Description

The [`IsInitialized`](https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/results/value-result.md#isinitialized) property has been made publicly accessible in [`ValueResult<TFailure, TSuccess>`](https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/results/value-result.md), allowing consumers to explicitly check whether a result is in its default (uninitialized) state. This change improves clarity and usability by enabling direct validation without relying on exceptions, supporting safer and more predictable usage in conditional flows.