### PR TITLE
build: update `.NET SDK` from 9.0.304 to 9.0.305

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
 	"sdk": {
 		"allowPrerelease": false,
 		"rollForward": "latestFeature",
-		"version": "9.0.304"
+		"version": "9.0.305"
 	}
 }


### PR DESCRIPTION
# Pull request

## Table of contents

1. [Description](#description)

### Description

[`.NET SDK`](https://dotnet.microsoft.com/en-us/download/dotnet/9.0) was updated from [9.0.304](https://github.com/dotnet/core/blob/main/release-notes/9.0/9.0.8/9.0.8.md) to [9.0.305](https://github.com/dotnet/core/blob/main/release-notes/9.0/9.0.9/9.0.9.md).
