### PR TITLE
build: add support for `AOT`

### DIFF
--- a/libraries/core/source/Sagitta.Core.csproj
+++ b/libraries/core/source/Sagitta.Core.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
+		<IsAotCompatible>true</IsAotCompatible>
+		<VerifyReferenceAotCompatibility>true</VerifyReferenceAotCompatibility>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 		<NoWarn>$(NoWarn); CA2225; RCS1146</NoWarn>
 		<IsPackable>true</IsPackable>

--- a/libraries/shared/source/Sagitta.Shared.csproj
+++ b/libraries/shared/source/Sagitta.Shared.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
+		<IsAotCompatible>true</IsAotCompatible>
+		<VerifyReferenceAotCompatibility>true</VerifyReferenceAotCompatibility>
 		<NoWarn>$(NoWarn); CA1034; CA1716</NoWarn>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>


### PR DESCRIPTION
# Pull request

## Table of contents

1. [Description](#description)

### Description

Enables **[Native AOT](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot)** and **Trimming** compatibility for the Sagitta ecosystem, targeting **.NET 10**. This ensures a zero-warning integration for high-performance and cloud-native applications. Key benefits include:

- **Zero-Warning Build**: Provides a seamless experience for consumers publishing native binaries.
- **Optimized Performance**: Supports instant startup and a reduced memory footprint.
- **Native-Ready**: Fully aligns with .NET 10 standards for high-efficiency environments.